### PR TITLE
[fix] Fix autoreview naming

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -34,6 +34,14 @@ jobs:
               pull_number: number,
             });
 
+            // Get PR author
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+            const prAuthor = pullRequest.user.login;
+
             // Determine which reviewers to request based on changed files
             let reviewersToRequest = new Set(defaultReviewers);
 
@@ -44,6 +52,9 @@ jobs:
                 }
               }
             }
+
+            // Exclude PR author from reviewers
+            reviewersToRequest.delete(prAuthor);
 
             // Request reviews
             if (reviewersToRequest.size > 0) {


### PR DESCRIPTION
Fixes the autoreview workflow which was using the same name in a local scope. 

<!-- Brief description of the changes -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
