### PR TITLE
Made content in ChatCompletionResponseMessage an optional field.

### DIFF
--- a/src/inference_endpoint/openai/openai_adapter.py
+++ b/src/inference_endpoint/openai/openai_adapter.py
@@ -158,6 +158,9 @@ class OpenAIAdapter(HttpRequestAdapter):
         # Set default values for optional fields if missing
         response_dict["choices"][0]["message"]["refusal"] = "None"
         response_dict["choices"][0]["logprobs"] = {"content": [], "refusal": []}
-        if "content" not in response_dict["choices"][0]["message"] or response_dict["choices"][0]["message"]["content"] is None:
+        if (
+            "content" not in response_dict["choices"][0]["message"]
+            or response_dict["choices"][0]["message"]["content"] is None
+        ):
             response_dict["choices"][0]["message"]["content"] = "None"
         return CreateChatCompletionResponse(**response_dict, ignore_extra=True)


### PR DESCRIPTION
## What does this PR do?

This PR makes the field `content` in ChatCompletionResponseMessage optional, to make it compatible with the model `gpt-oss-120b`. See the linked issue for details: #24 .

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

Closes #24 

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [x] Manual testing completed

## Checklist

- [x] Code follows project style
- [x] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
