### PR TITLE
fix : Fix test non-determinism:

### DIFF
--- a/src/inference_endpoint/commands/probe.py
+++ b/src/inference_endpoint/commands/probe.py
@@ -202,8 +202,8 @@ async def run_probe_command(args: argparse.Namespace) -> None:
             # Show sample responses for sanity check
             if responses:
                 logger.info(f"✓ Sample responses ({len(responses)} collected):")
-                # Show first 10 responses
-                for query_id, response in responses[:10]:
+                # Show all responses - can be overwhelming, but useful for debugging
+                for query_id, response in responses:
                     # Truncate long responses
                     response_preview = (
                         response[:100] + "..." if len(response) > 100 else response


### PR DESCRIPTION
## What does this PR do?
The probe command truncates the responses to the probe requests and only keeps the first 10 responses. This can cause test failures as the responses are out of order and particularly in CI the probe-0 would be missing in the first 10 requests. 
The fix is to not truncate the responses which can be verbose but it prevents failures such as this one from creeping.

Closes #47 

TODO 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
