### PR TITLE
[fix] Handle case with string response

### DIFF
--- a/src/inference_endpoint/metrics/reporter.py
+++ b/src/inference_endpoint/metrics/reporter.py
@@ -1078,7 +1078,9 @@ class MetricsReporter:
             if isinstance(output_sequence, str):
                 output_sequence = [output_sequence]
             if not isinstance(output_sequence, list):
-                logging.warning(f"Output sequence for sample {sample_uuid} is not a list but {type(output_sequence)}: {output_sequence}")
+                logging.warning(
+                    f"Output sequence for sample {sample_uuid} is not a list but {type(output_sequence)}: {output_sequence}"
+                )
                 continue
 
             all_chunks = output_sequence

--- a/tests/unit/metrics/test_reporter.py
+++ b/tests/unit/metrics/test_reporter.py
@@ -112,7 +112,9 @@ def test_derive_tpot_with_string_output(tmp_path, sample_uuids, tokenizer):
     assert tpot_rows is None
 
 
-def test_derive_tpot_string_output_with_list_reasoning(tmp_path, sample_uuids, tokenizer):
+def test_derive_tpot_string_output_with_list_reasoning(
+    tmp_path, sample_uuids, tokenizer
+):
     """Test that derive_TPOT computes TPOT when string output is paired with a list reasoning sequence.
 
     The fix wraps string outputs into a single-element list so they can be combined with
@@ -137,7 +139,9 @@ def test_derive_tpot_string_output_with_list_reasoning(tmp_path, sample_uuids, t
                     uuid1,
                     SampleEvent.COMPLETE.value,
                     10211,
-                    orjson.dumps({"output": "the answer", "reasoning": ["thought step"]}),
+                    orjson.dumps(
+                        {"output": "the answer", "reasoning": ["thought step"]}
+                    ),
                 ),
                 ("", SessionEvent.TEST_ENDED.value, 10300, b""),
             ],


### PR DESCRIPTION
Fixes TPOT calculation when the response type is a string.

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
