### PR TITLE
[Feat] Q3VL: Exclude calibration dataset from testing

### DIFF
--- a/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
+++ b/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
@@ -32,7 +32,7 @@ from .metadata import ProductMetadata
 
 logger = getLogger(__name__)
 
-CALIBRATION_SAMPLE_INDEX = [
+CALIBRATION_SAMPLE_INDEX = {
     20232,
     21162,
     33584,
@@ -53,7 +53,7 @@ CALIBRATION_SAMPLE_INDEX = [
     39746,
     13568,
     22527,
-]
+}
 
 
 def _process_sample_to_row(sample: dict[str, Any]) -> dict[str, Any]:

--- a/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
+++ b/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
@@ -32,6 +32,28 @@ from .metadata import ProductMetadata
 
 logger = getLogger(__name__)
 
+CALIBRATION_SAMPLE_INDEX = [
+    20232,
+    21162,
+    33584,
+    46825,
+    45190,
+    46143,
+    14189,
+    16658,
+    26406,
+    9565,
+    33733,
+    31057,
+    47465,
+    33503,
+    42293,
+    7768,
+    1962,
+    39746,
+    13568,
+    22527,
+]
 
 def _process_sample_to_row(sample: dict[str, Any]) -> dict[str, Any]:
     """Convert a single HF dataset sample to a row dict for parquet storage.
@@ -148,6 +170,8 @@ class ShopifyProductCatalogue(
             desc=f"Converting images ({split_key})",
             unit="rows",
         ):
+            if i in CALIBRATION_SAMPLE_INDEX:
+                continue
             sample = ds[i]
             all_rows.append(_process_sample_to_row(sample))
 

--- a/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
+++ b/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
@@ -32,7 +32,7 @@ from .metadata import ProductMetadata
 
 logger = getLogger(__name__)
 
-CALIBRATION_SAMPLE_INDEX = {
+DEFAULT_CALIBRATION_SAMPLE_INDEX = {
     20232,
     21162,
     33584,
@@ -124,6 +124,7 @@ class ShopifyProductCatalogue(
         force: bool = False,
         token: str | None = None,
         revision: str = "main",
+        calibration_sample_index: set[int] | None = DEFAULT_CALIBRATION_SAMPLE_INDEX,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Generate the Shopify product catalogue dataset.
@@ -171,7 +172,7 @@ class ShopifyProductCatalogue(
             desc=f"Converting images ({split_key})",
             unit="rows",
         ):
-            if i in CALIBRATION_SAMPLE_INDEX:
+            if calibration_sample_index is not None and i in calibration_sample_index:
                 continue
             sample = ds[i]
             all_rows.append(_process_sample_to_row(sample))

--- a/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
+++ b/src/inference_endpoint/dataset_manager/predefined/shopify_product_catalogue/__init__.py
@@ -55,6 +55,7 @@ CALIBRATION_SAMPLE_INDEX = [
     22527,
 ]
 
+
 def _process_sample_to_row(sample: dict[str, Any]) -> dict[str, Any]:
     """Convert a single HF dataset sample to a row dict for parquet storage.
 


### PR DESCRIPTION
## What does this PR do?
Exclude Calibration dataset from perf/acc testing as required for v6.1 round.

<!-- Brief description of the changes -->

## Type of change

- [x] New feature


## Related issues

<!-- Link any related issues: Closes #123 -->


## Checklist

- [x] Code follows project style
- [x] Pre-commit hooks pass
