### PR TITLE
fix: disable TCP keepalive by default to avoid connection timeouts

### DIFF
--- a/src/inference_endpoint/endpoint_client/http.py
+++ b/src/inference_endpoint/endpoint_client/http.py
@@ -56,9 +56,13 @@ class _SocketConfig:
     # we hit lots of connection timed out errors in offline and high-concurrency modes,
     # disabling since we handle dead-connections in http.py connection_lost/eof_received
     SO_KEEPALIVE: int = 0  # Disabled
-    TCP_KEEPIDLE: int = 1  # Probe after 1s idle (disabled)
-    TCP_KEEPCNT: int = 5  # 5 failed probes = dead (disabled)
-    TCP_KEEPINTVL: int = 1  # 1s between probes (disabled)
+    TCP_KEEPIDLE: int = (
+        1  # Probe after 1s idle (only used when SO_KEEPALIVE is enabled)
+    )
+    TCP_KEEPCNT: int = (
+        5  # 5 failed probes = dead (only used when SO_KEEPALIVE is enabled)
+    )
+    TCP_KEEPINTVL: int = 1  # 1s between probes (only used when SO_KEEPALIVE is enabled)
 
     # Socket buffer sizing: sliding windows, not full-message buffers.
     # The event loop reads eagerly so the buffer only holds data between

--- a/src/inference_endpoint/endpoint_client/http.py
+++ b/src/inference_endpoint/endpoint_client/http.py
@@ -52,12 +52,13 @@ class _SocketConfig:
     # Connection keepalive-probe settings for long-lived connections
     # client kernel sends probe, server's kernel ACKs - no application overhead
     #
-    # TODO(vir): verify impact on failure-detection, we want to fail fast
-    # detection time: KEEPIDLE + (KEEPCNT × KEEPINTVL) = 1 + 5×1 = 6s
-    SO_KEEPALIVE: int = 1  # Enable keepalive at socket level
-    TCP_KEEPIDLE: int = 1  # Probe after 1s idle
-    TCP_KEEPCNT: int = 5  # 5 failed probes = dead
-    TCP_KEEPINTVL: int = 1  # 1s between probes
+    # NOTE(vir):
+    # we hit lots of connection timed out errors in offline and high-concurrency modes,
+    # disabling since we handle dead-connections in http.py connection_lost/eof_received
+    SO_KEEPALIVE: int = 0  # Disabled
+    TCP_KEEPIDLE: int = 1  # Probe after 1s idle (disabled)
+    TCP_KEEPCNT: int = 5  # 5 failed probes = dead (disabled)
+    TCP_KEEPINTVL: int = 1  # 1s between probes (disabled)
 
     # Socket buffer sizing: sliding windows, not full-message buffers.
     # The event loop reads eagerly so the buffer only holds data between
@@ -79,11 +80,9 @@ class _SocketConfig:
         # Low-latency optimizations for streaming
         sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, cls.TCP_NODELAY)
 
-        # Connection keepalive settings for long-lived SSE connections
+        # Connection keepalive (disabled by default, tune via SO_KEEPALIVE)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, cls.SO_KEEPALIVE)
-
-        # Fine-tune keepalive timing
-        if hasattr(socket, "TCP_KEEPIDLE"):
+        if cls.SO_KEEPALIVE and hasattr(socket, "TCP_KEEPIDLE"):
             sock.setsockopt(socket.SOL_TCP, socket.TCP_KEEPIDLE, cls.TCP_KEEPIDLE)
             sock.setsockopt(socket.SOL_TCP, socket.TCP_KEEPINTVL, cls.TCP_KEEPINTVL)
             sock.setsockopt(socket.SOL_TCP, socket.TCP_KEEPCNT, cls.TCP_KEEPCNT)

--- a/tests/unit/endpoint_client/test_http.py
+++ b/tests/unit/endpoint_client/test_http.py
@@ -16,6 +16,7 @@
 """Tests for HTTP API implementation."""
 
 import asyncio
+import socket
 from urllib.parse import urlparse
 
 import httptools
@@ -25,6 +26,7 @@ from inference_endpoint.endpoint_client.http import (
     ConnectionPool,
     HttpRequestTemplate,
     HttpResponseProtocol,
+    _SocketConfig,
 )
 from inference_endpoint.testing.echo_server import EchoServer
 
@@ -420,6 +422,17 @@ class TestHttpResponseProtocol:
 
 class TestConnectionPool:
     """Tests for connection pooling."""
+
+    @pytest.mark.asyncio
+    async def test_socket_options_reflect_defaults(self, pool):
+        """Newly created connections have SO_KEEPALIVE disabled by default."""
+        conn = await pool.acquire()
+        try:
+            sock = conn.transport.get_extra_info("socket")
+            keepalive = sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
+            assert keepalive == _SocketConfig.SO_KEEPALIVE
+        finally:
+            pool.release(conn)
 
     @pytest.mark.asyncio
     async def test_acquire_creates_and_reuses(self, pool):


### PR DESCRIPTION
Keepalive probes caused connection timeout errors in offline and high-concurrency modes. Dead connections are already handled by connection_lost/eof_received callbacks in the protocol layer.

attempt to close https://github.com/mlcommons/endpoints/issues/202

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
