### PR TITLE
chore(deps): restrict dependabot to security-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     labels: ["dependencies", "security"]
 
   - package-ecosystem: "github-actions"
@@ -13,7 +13,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     labels: ["dependencies", "ci"]
 
   - package-ecosystem: "docker"
@@ -21,5 +21,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     labels: ["dependencies", "docker"]


### PR DESCRIPTION
## Summary
- Set `open-pull-requests-limit: 0` on all three dependabot ecosystems (pip, github-actions, docker)
- Per [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot-yml-file#open-pull-requests-limit), a limit of 0 disables version-update PRs; security-advisory-driven PRs ignore this limit and continue to flow

## Test plan
- [ ] Confirm no new version-bump PRs are opened on the next Monday schedule
- [ ] Confirm security advisories still produce PRs (verify against a known advisory or wait for next one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)