### PR TITLE
Add support for benchmarking TLS endpoints

### DIFF
--- a/src/inference_endpoint/commands/probe.py
+++ b/src/inference_endpoint/commands/probe.py
@@ -58,6 +58,13 @@ class ProbeConfig(BaseModel):
     prompt: str = Field(
         "Please write me a joke in 30 words.", description="Test prompt"
     )
+    insecure: Annotated[
+        bool,
+        cyclopts.Parameter(
+            alias="--insecure",
+            help="Skip TLS certificate verification",
+        ),
+    ] = False
 
 
 def execute_probe(config: ProbeConfig) -> None:
@@ -114,6 +121,7 @@ async def _probe_async(config: ProbeConfig) -> None:
             api_type=api_type,
             num_workers=1,
             warmup_connections=0,
+            insecure=config.insecure,
         )
         # Client creates its own event loop in a separate thread
         client = HTTPEndpointClient(http_config)

--- a/src/inference_endpoint/config/templates/concurrency_template_full.yaml
+++ b/src/inference_endpoint/config/templates/concurrency_template_full.yaml
@@ -69,6 +69,7 @@ settings:
     worker_initialization_timeout: 60.0  # Worker init timeout (seconds)
     worker_graceful_shutdown_wait: 0.5  # Post-run graceful shutdown wait (seconds)
     worker_force_kill_timeout: 0.5  # Force kill timeout after graceful wait (seconds)
+    insecure: false  # Skip TLS certificate verification
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system

--- a/src/inference_endpoint/config/templates/offline_template_full.yaml
+++ b/src/inference_endpoint/config/templates/offline_template_full.yaml
@@ -69,6 +69,7 @@ settings:
     worker_initialization_timeout: 60.0  # Worker init timeout (seconds)
     worker_graceful_shutdown_wait: 0.5  # Post-run graceful shutdown wait (seconds)
     worker_force_kill_timeout: 0.5  # Force kill timeout after graceful wait (seconds)
+    insecure: false  # Skip TLS certificate verification
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system

--- a/src/inference_endpoint/config/templates/online_template_full.yaml
+++ b/src/inference_endpoint/config/templates/online_template_full.yaml
@@ -69,6 +69,7 @@ settings:
     worker_initialization_timeout: 60.0  # Worker init timeout (seconds)
     worker_graceful_shutdown_wait: 0.5  # Post-run graceful shutdown wait (seconds)
     worker_force_kill_timeout: 0.5  # Force kill timeout after graceful wait (seconds)
+    insecure: false  # Skip TLS certificate verification
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system

--- a/src/inference_endpoint/endpoint_client/config.py
+++ b/src/inference_endpoint/endpoint_client/config.py
@@ -136,6 +136,15 @@ class HTTPClientConfig(WithUpdatesMixin, BaseModel):
         0.5, description="Force kill timeout after graceful wait (seconds)"
     )
 
+    # Set to True to skip certificate verification (e.g. self-signed certs).
+    insecure: Annotated[
+        bool,
+        cyclopts.Parameter(
+            alias="--insecure",
+            help="Skip TLS certificate verification",
+        ),
+    ] = Field(False, description="Skip TLS certificate verification")
+
     # Connection idle timeout - discard connections idle longer than this.
     # Two fold benefits:
     # 1. Prevents keep-alive race condition where server closes idle connection

--- a/src/inference_endpoint/endpoint_client/http.py
+++ b/src/inference_endpoint/endpoint_client/http.py
@@ -244,11 +244,16 @@ class HttpResponseProtocol(asyncio.Protocol):
 
         See: https://bugs.python.org/issue44805 (asyncio EOF detection on reused sockets)
         See: https://superuser.com/questions/298919/tcp-half-open-vs-half-closed
+
+        Return False so asyncio closes the transport itself, which then triggers
+        connection_lost() promptly (resolving any pending _body_future). TLS does
+        not support TCP half-close, so returning True is a no-op on SSL transports
+        (asyncio logs a warning) — False is the correct value for both plain and
+        SSL connections.
         """
         self._connection_lost = True
         self._signal_stream_end()  # Unblock any waiting iter_body()
-        # Return True to keep transport open briefly for pending data processing
-        return True
+        return False
 
     # -------------------------------------------------------------------------
     # httptools callbacks

--- a/src/inference_endpoint/endpoint_client/worker.py
+++ b/src/inference_endpoint/endpoint_client/worker.py
@@ -159,6 +159,9 @@ class Worker:
 
         if self._scheme == "https":
             self._ssl_context = ssl.create_default_context()
+            if http_config.insecure:
+                self._ssl_context.check_hostname = False
+                self._ssl_context.verify_mode = ssl.CERT_NONE
 
         # HTTP components (initialized in run())
         self._pool: ConnectionPool = None  # type: ignore[assignment]

--- a/tests/unit/endpoint_client/test_http.py
+++ b/tests/unit/endpoint_client/test_http.py
@@ -329,7 +329,9 @@ class TestHttpResponseProtocol:
         assert not protocol2._connection_lost
         result = protocol2.eof_received()
         assert protocol2._connection_lost is True
-        assert result is True
+        # Returns False so asyncio closes the transport itself; required for
+        # SSL transports (which don't support TCP half-close).
+        assert result is False
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
Enable the benchmark and probe commands to target HTTPS endpoints, including those serving self-signed certificates via a new --insecure flag that skips TLS certificate verification on the SSL context used by worker connections.

Also fix HttpResponseProtocol.eof_received() to return False so asyncio closes the transport itself; returning True is a no-op on SSL transports (which don't support TCP half-close) and was leaving pending body futures unresolved on connection teardown.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [x] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [x] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
