### PR TITLE
feat: show progress bar during multi-turn ISL pre-compute

### DIFF
--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -343,6 +343,7 @@ def _precompute_isl_for_multi_turn(
         unit="turn",
         smoothing=0,
         mininterval=2.0,
+        disable=not logger.isEnabledFor(logging.INFO),
     ):
         messages = sample.get("messages")
         if not messages:

--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -335,7 +335,15 @@ def _precompute_isl_for_multi_turn(
         return
     skipped = 0
     first_failure_logged = False
-    for sample in dataloader.data or []:
+    samples = dataloader.data or []
+    for sample in tqdm(
+        samples,
+        total=len(samples),
+        desc="Pre-computing ISL token counts",
+        unit="turn",
+        smoothing=0,
+        mininterval=2.0,
+    ):
         messages = sample.get("messages")
         if not messages:
             continue


### PR DESCRIPTION
## What does this PR do?

Show a `tqdm` progress bar over the multi-turn ISL pre-computation loop in `_precompute_isl_for_multi_turn` (`src/inference_endpoint/commands/benchmark/execute.py`).

*Why*: On large multi-turn datasets the serial `apply_chat_template` loop runs for minutes with no output (30 min on a 26k-turn agentic-coding dataset, with the entire benchmark taking less than 50 minutes), so it looks like a hang.  This PR adds a progress bar.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor/cleanup

## Related issues

N/A

## Testing

- [ ] Tests added/updated
- [x] All tests pass locally
- [x] Manual testing completed

## Checklist

- [x] Code follows project style
- [x] Pre-commit hooks pass
- [x] Documentation updated (if needed)