### PR TITLE
Add configurable options to drain_in_flight timeout in different phases

### DIFF
--- a/examples/08_Qwen3-VL-235B-A22B_Example/interactive_qwen3_vl_235b_a22b_shopify_8k.yaml
+++ b/examples/08_Qwen3-VL-235B-A22B_Example/interactive_qwen3_vl_235b_a22b_shopify_8k.yaml
@@ -42,8 +42,8 @@ settings:
     worker_initialization_timeout: 120
 
   warmup:
-    enabled: true  # Enable warmup phase before performance run
-    n_requests: 400  # Warmup request count (None = full dataset once)
+    enabled: true # Enable warmup phase before performance run
+    n_requests: 400 # Warmup request count (None = full dataset once)
     salt: false
 
 endpoint_config:

--- a/examples/08_Qwen3-VL-235B-A22B_Example/interactive_qwen3_vl_235b_a22b_shopify_8k.yaml
+++ b/examples/08_Qwen3-VL-235B-A22B_Example/interactive_qwen3_vl_235b_a22b_shopify_8k.yaml
@@ -41,6 +41,11 @@ settings:
     max_connections: 1000
     worker_initialization_timeout: 120
 
+  warmup:
+    enabled: true  # Enable warmup phase before performance run
+    n_requests: 400  # Warmup request count (None = full dataset once)
+    salt: false
+
 endpoint_config:
   endpoints:
     - "http://localhost:8000"

--- a/examples/08_Qwen3-VL-235B-A22B_Example/offline_qwen3_vl_235b_a22b_shopify.yaml
+++ b/examples/08_Qwen3-VL-235B-A22B_Example/offline_qwen3_vl_235b_a22b_shopify.yaml
@@ -40,12 +40,12 @@ settings:
     # Increase timeout for slow worker startup (spawn, imports). Default 40s may be too short.
     worker_initialization_timeout: 120
   drain:
-    warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
-    performance_timeout_s: null  # Performance drain timeout in seconds (None = wait indefinitely)
-    accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
+    warmup_timeout_s: 240.0 # Warmup drain timeout in seconds (None = wait indefinitely)
+    performance_timeout_s: null # Performance drain timeout in seconds (None = wait indefinitely)
+    accuracy_timeout_s: null # Accuracy drain timeout in seconds (None = wait indefinitely)
   warmup:
-    enabled: true  # Enable warmup phase before performance run
-    n_requests: 1600  # Warmup request count (None = full dataset once)
+    enabled: true # Enable warmup phase before performance run
+    n_requests: 1600 # Warmup request count (None = full dataset once)
     salt: false
 
 endpoint_config:

--- a/examples/08_Qwen3-VL-235B-A22B_Example/offline_qwen3_vl_235b_a22b_shopify.yaml
+++ b/examples/08_Qwen3-VL-235B-A22B_Example/offline_qwen3_vl_235b_a22b_shopify.yaml
@@ -45,7 +45,7 @@ settings:
     accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
   warmup:
     enabled: true  # Enable warmup phase before performance run
-    n_requests: 400  # Warmup request count (None = full dataset once)
+    n_requests: 1600  # Warmup request count (None = full dataset once)
     salt: false
 
 endpoint_config:

--- a/examples/08_Qwen3-VL-235B-A22B_Example/offline_qwen3_vl_235b_a22b_shopify.yaml
+++ b/examples/08_Qwen3-VL-235B-A22B_Example/offline_qwen3_vl_235b_a22b_shopify.yaml
@@ -39,6 +39,14 @@ settings:
     max_connections: 1000
     # Increase timeout for slow worker startup (spawn, imports). Default 40s may be too short.
     worker_initialization_timeout: 120
+  drain:
+    warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
+    performance_timeout_s: null  # Performance drain timeout in seconds (None = wait indefinitely)
+    accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
+  warmup:
+    enabled: true  # Enable warmup phase before performance run
+    n_requests: 400  # Warmup request count (None = full dataset once)
+    salt: false
 
 endpoint_config:
   endpoints:

--- a/examples/08_Qwen3-VL-235B-A22B_Example/server_qwen3_vl_235b_a22b_shopify.yaml
+++ b/examples/08_Qwen3-VL-235B-A22B_Example/server_qwen3_vl_235b_a22b_shopify.yaml
@@ -40,6 +40,10 @@ settings:
     max_connections: 1000
     # Increase timeout for slow worker startup (spawn, imports). Default 40s may be too short.
     worker_initialization_timeout: 120
+  warmup:
+    enabled: true  # Enable warmup phase before performance run
+    n_requests: 1600  # Warmup request count (None = full dataset once)
+    salt: false
 
 endpoint_config:
   endpoints:

--- a/examples/08_Qwen3-VL-235B-A22B_Example/server_qwen3_vl_235b_a22b_shopify.yaml
+++ b/examples/08_Qwen3-VL-235B-A22B_Example/server_qwen3_vl_235b_a22b_shopify.yaml
@@ -41,8 +41,8 @@ settings:
     # Increase timeout for slow worker startup (spawn, imports). Default 40s may be too short.
     worker_initialization_timeout: 120
   warmup:
-    enabled: true  # Enable warmup phase before performance run
-    n_requests: 1600  # Warmup request count (None = full dataset once)
+    enabled: true # Enable warmup phase before performance run
+    n_requests: 1600 # Warmup request count (None = full dataset once)
     salt: false
 
 endpoint_config:

--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -521,7 +521,13 @@ def _build_phases(
             load_pattern=acc_load_pattern,
         )
         phases.append(
-            PhaseConfig(eval_cfg.dataset_name, acc_settings, acc_ds, PhaseType.ACCURACY)
+            PhaseConfig(
+                eval_cfg.dataset_name,
+                acc_settings,
+                acc_ds,
+                PhaseType.ACCURACY,
+                drain_timeout=None,
+            )
         )
 
     return phases

--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -452,6 +452,7 @@ def _build_phases(
 ) -> list[PhaseConfig]:
     """Build the phase list from BenchmarkContext."""
     phases: list[PhaseConfig] = []
+    drain_cfg = ctx.config.settings.drain
 
     # Warmup phase (optional, before performance)
     warmup_cfg = ctx.config.settings.warmup
@@ -479,6 +480,7 @@ def _build_phases(
                 warmup_dataset,
                 PhaseType.WARMUP,
                 drain_after=warmup_cfg.drain,
+                drain_timeout=drain_cfg.warmup_timeout_s,
             )
         )
 
@@ -490,6 +492,7 @@ def _build_phases(
             ctx.dataloader,
             PhaseType.PERFORMANCE,
             strategy=perf_strategy,
+            drain_timeout=drain_cfg.performance_timeout_s,
         )
     )
 
@@ -526,7 +529,7 @@ def _build_phases(
                 acc_settings,
                 acc_ds,
                 PhaseType.ACCURACY,
-                drain_timeout=None,
+                drain_timeout=drain_cfg.accuracy_timeout_s,
             )
         )
 

--- a/src/inference_endpoint/config/schema.py
+++ b/src/inference_endpoint/config/schema.py
@@ -483,6 +483,46 @@ class WarmupConfig(BaseModel):
     ] = Field(42, description="RNG seed for warmup scheduling and sample ordering")
 
 
+class DrainConfig(BaseModel):
+    """Per-phase in-flight response drain timeout configuration."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    warmup_timeout_s: Annotated[
+        float | None,
+        cyclopts.Parameter(
+            alias="--warmup-drain-timeout",
+            help="Warmup drain timeout in seconds (None = wait indefinitely)",
+        ),
+    ] = Field(
+        240.0,
+        gt=0,
+        description="Warmup drain timeout in seconds (None = wait indefinitely)",
+    )
+    performance_timeout_s: Annotated[
+        float | None,
+        cyclopts.Parameter(
+            alias="--performance-drain-timeout",
+            help="Performance drain timeout in seconds (None = wait indefinitely)",
+        ),
+    ] = Field(
+        240.0,
+        gt=0,
+        description="Performance drain timeout in seconds (None = wait indefinitely)",
+    )
+    accuracy_timeout_s: Annotated[
+        float | None,
+        cyclopts.Parameter(
+            alias="--accuracy-drain-timeout",
+            help="Accuracy drain timeout in seconds (None = wait indefinitely)",
+        ),
+    ] = Field(
+        None,
+        gt=0,
+        description="Accuracy drain timeout in seconds (None = wait indefinitely)",
+    )
+
+
 @cyclopts.Parameter(name="*")
 class Settings(BaseModel):
     """Test settings."""
@@ -492,6 +532,7 @@ class Settings(BaseModel):
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     load_pattern: LoadPattern = Field(default_factory=LoadPattern)
     client: HTTPClientConfig = Field(default_factory=HTTPClientConfig)
+    drain: DrainConfig = Field(default_factory=DrainConfig)
     warmup: WarmupConfig = Field(default_factory=WarmupConfig)
 
 

--- a/src/inference_endpoint/config/schema.py
+++ b/src/inference_endpoint/config/schema.py
@@ -532,7 +532,10 @@ class Settings(BaseModel):
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     load_pattern: LoadPattern = Field(default_factory=LoadPattern)
     client: HTTPClientConfig = Field(default_factory=HTTPClientConfig)
-    drain: DrainConfig = Field(default_factory=DrainConfig)
+    drain: DrainConfig = Field(
+        default_factory=DrainConfig,
+        description="Per-phase in-flight response drain timeout configuration",
+    )
     warmup: WarmupConfig = Field(default_factory=WarmupConfig)
 
 

--- a/src/inference_endpoint/config/templates/concurrency_template_full.yaml
+++ b/src/inference_endpoint/config/templates/concurrency_template_full.yaml
@@ -73,6 +73,10 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
+  drain:
+    warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
+    performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
+    accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
   warmup:
     enabled: false  # Enable warmup phase before performance run
     n_requests: null  # Warmup request count (None = full dataset once)

--- a/src/inference_endpoint/config/templates/concurrency_template_full.yaml
+++ b/src/inference_endpoint/config/templates/concurrency_template_full.yaml
@@ -73,7 +73,7 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
-  drain:  # Drain in-flight warmup requests before starting the performance phase
+  drain:
     warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
     performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
     accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
@@ -81,7 +81,7 @@ settings:
     enabled: false  # Enable warmup phase before performance run
     n_requests: null  # Warmup request count (None = full dataset once)
     salt: false  # Prepend a unique random hex salt to each warmup prompt
-    drain: false  # Drain in-flight warmup requests before starting the performance phase
+    drain: false
     warmup_random_seed: 42  # RNG seed for warmup scheduling and sample ordering
 endpoint_config:
   endpoints:  # Endpoint URL(s). Must include scheme, e.g. 'http://host:port'.

--- a/src/inference_endpoint/config/templates/concurrency_template_full.yaml
+++ b/src/inference_endpoint/config/templates/concurrency_template_full.yaml
@@ -73,7 +73,7 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
-  drain:
+  drain:  # Drain in-flight warmup requests before starting the performance phase
     warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
     performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
     accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)

--- a/src/inference_endpoint/config/templates/offline_template_full.yaml
+++ b/src/inference_endpoint/config/templates/offline_template_full.yaml
@@ -73,6 +73,10 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
+  drain:
+    warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
+    performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
+    accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
   warmup:
     enabled: false  # Enable warmup phase before performance run
     n_requests: null  # Warmup request count (None = full dataset once)

--- a/src/inference_endpoint/config/templates/offline_template_full.yaml
+++ b/src/inference_endpoint/config/templates/offline_template_full.yaml
@@ -73,7 +73,7 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
-  drain:  # Drain in-flight warmup requests before starting the performance phase
+  drain:
     warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
     performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
     accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
@@ -81,7 +81,7 @@ settings:
     enabled: false  # Enable warmup phase before performance run
     n_requests: null  # Warmup request count (None = full dataset once)
     salt: false  # Prepend a unique random hex salt to each warmup prompt
-    drain: false  # Drain in-flight warmup requests before starting the performance phase
+    drain: false
     warmup_random_seed: 42  # RNG seed for warmup scheduling and sample ordering
 endpoint_config:
   endpoints:  # Endpoint URL(s). Must include scheme, e.g. 'http://host:port'.

--- a/src/inference_endpoint/config/templates/offline_template_full.yaml
+++ b/src/inference_endpoint/config/templates/offline_template_full.yaml
@@ -73,7 +73,7 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
-  drain:
+  drain:  # Drain in-flight warmup requests before starting the performance phase
     warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
     performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
     accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)

--- a/src/inference_endpoint/config/templates/online_template_full.yaml
+++ b/src/inference_endpoint/config/templates/online_template_full.yaml
@@ -73,6 +73,10 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
+  drain:
+    warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
+    performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
+    accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
   warmup:
     enabled: false  # Enable warmup phase before performance run
     n_requests: null  # Warmup request count (None = full dataset once)

--- a/src/inference_endpoint/config/templates/online_template_full.yaml
+++ b/src/inference_endpoint/config/templates/online_template_full.yaml
@@ -73,7 +73,7 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
-  drain:  # Drain in-flight warmup requests before starting the performance phase
+  drain:
     warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
     performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
     accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)
@@ -81,7 +81,7 @@ settings:
     enabled: false  # Enable warmup phase before performance run
     n_requests: null  # Warmup request count (None = full dataset once)
     salt: false  # Prepend a unique random hex salt to each warmup prompt
-    drain: false  # Drain in-flight warmup requests before starting the performance phase
+    drain: false
     warmup_random_seed: 42  # RNG seed for warmup scheduling and sample ordering
 endpoint_config:
   endpoints:  # Endpoint URL(s). Must include scheme, e.g. 'http://host:port'.

--- a/src/inference_endpoint/config/templates/online_template_full.yaml
+++ b/src/inference_endpoint/config/templates/online_template_full.yaml
@@ -73,7 +73,7 @@ settings:
     max_idle_time: 4.0  # Discard connections idle longer than this (seconds)
     min_required_connections: -1  # Min connections to initialize (-1=auto, 0=disabled)
     worker_gc_mode: relaxed  # Worker GC strategy | options: disabled, relaxed, system
-  drain:
+  drain:  # Drain in-flight warmup requests before starting the performance phase
     warmup_timeout_s: 240.0  # Warmup drain timeout in seconds (None = wait indefinitely)
     performance_timeout_s: 240.0  # Performance drain timeout in seconds (None = wait indefinitely)
     accuracy_timeout_s: null  # Accuracy drain timeout in seconds (None = wait indefinitely)

--- a/src/inference_endpoint/load_generator/session.py
+++ b/src/inference_endpoint/load_generator/session.py
@@ -90,6 +90,7 @@ class PhaseConfig:
     dataset: Dataset
     phase_type: PhaseType = PhaseType.PERFORMANCE
     drain_after: bool = True
+    drain_timeout: float | None = 240.0
     strategy: LoadStrategy | None = field(default=None, compare=False)
 
 
@@ -417,7 +418,7 @@ class BenchmarkSession:
             self._strategy_task = None
 
         if phase.drain_after:
-            await self._drain_inflight(phase_issuer)
+            await self._drain_inflight(phase_issuer, phase.drain_timeout)
 
         if phase.phase_type == PhaseType.PERFORMANCE:
             self._publish_session_event(SessionEventType.STOP_PERFORMANCE_TRACKING)
@@ -442,21 +443,35 @@ class BenchmarkSession:
             end_time_ns=phase_end,
         )
 
-    async def _drain_inflight(self, phase_issuer: PhaseIssuer) -> None:
+    async def _drain_inflight(
+        self, phase_issuer: PhaseIssuer, timeout: float | None = 240.0
+    ) -> None:
         """Wait for all in-flight responses from this phase to complete.
 
-        Hard-bounded at 240 s; logs an error and returns if exceeded so the
-        next phase starts regardless of stuck requests."""
+        Bounded by ``timeout`` seconds; on expiry logs an error and returns so
+        the next phase starts regardless of stuck requests. ``timeout=None``
+        waits indefinitely — accuracy phases use this because every sample must
+        complete and an offline burst over few connections legitimately exceeds
+        any fixed bound. A dropped transport still unblocks the wait via the
+        ``_receive_responses`` close path."""
         if phase_issuer.inflight <= 0 or self._stop_requested:
             return
         logger.info("Draining %d in-flight responses...", phase_issuer.inflight)
         self._drain_event.clear()
+        # Re-check after clear: a completion may have set the event between the
+        # initial inflight check and clear(), which would otherwise be lost.
+        if phase_issuer.inflight <= 0:
+            return
+        if timeout is None:
+            await self._drain_event.wait()
+            return
         try:
-            await asyncio.wait_for(self._drain_event.wait(), timeout=240.0)
+            await asyncio.wait_for(self._drain_event.wait(), timeout=timeout)
         except TimeoutError:
             logger.error(
-                "Drain timed out after 240 s with %d responses still in flight; "
+                "Drain timed out after %.0f s with %d responses still in flight; "
                 "proceeding to next phase.",
+                timeout,
                 phase_issuer.inflight,
             )
 

--- a/src/inference_endpoint/load_generator/session.py
+++ b/src/inference_endpoint/load_generator/session.py
@@ -458,10 +458,6 @@ class BenchmarkSession:
             return
         logger.info("Draining %d in-flight responses...", phase_issuer.inflight)
         self._drain_event.clear()
-        # Re-check after clear: a completion may have set the event between the
-        # initial inflight check and clear(), which would otherwise be lost.
-        if phase_issuer.inflight <= 0:
-            return
         if timeout is None:
             await self._drain_event.wait()
             return

--- a/src/inference_endpoint/load_generator/session.py
+++ b/src/inference_endpoint/load_generator/session.py
@@ -465,7 +465,7 @@ class BenchmarkSession:
             await asyncio.wait_for(self._drain_event.wait(), timeout=timeout)
         except TimeoutError:
             logger.error(
-                "Drain timed out after %.0f s with %d responses still in flight; "
+                "Drain timed out after %s s with %d responses still in flight; "
                 "proceeding to next phase.",
                 timeout,
                 phase_issuer.inflight,

--- a/src/inference_endpoint/load_generator/session.py
+++ b/src/inference_endpoint/load_generator/session.py
@@ -90,7 +90,7 @@ class PhaseConfig:
     dataset: Dataset
     phase_type: PhaseType = PhaseType.PERFORMANCE
     drain_after: bool = True
-    drain_timeout: float | None = 240.0
+    drain_timeout: float | None = None
     strategy: LoadStrategy | None = field(default=None, compare=False)
 
 
@@ -444,7 +444,7 @@ class BenchmarkSession:
         )
 
     async def _drain_inflight(
-        self, phase_issuer: PhaseIssuer, timeout: float | None = 240.0
+        self, phase_issuer: PhaseIssuer, timeout: float | None
     ) -> None:
         """Wait for all in-flight responses from this phase to complete.
 

--- a/tests/unit/commands/test_benchmark.py
+++ b/tests/unit/commands/test_benchmark.py
@@ -29,6 +29,7 @@ from inference_endpoint.commands.benchmark.cli import (
     online,
 )
 from inference_endpoint.commands.benchmark.execute import (
+    AccuracyConfiguration,
     BenchmarkContext,
     ResponseCollector,
     _build_phases,
@@ -562,6 +563,17 @@ class TestBuildPhases:
             total_samples=dataloader.num_samples(),
             accuracy_datasets=[],
             eval_configs=[],
+        )
+
+    def _make_eval_config(self, dataset):
+        return AccuracyConfiguration(
+            scorer=Scorer.get("pass_at_1"),
+            extractor=None,
+            dataset_name="accuracy",
+            dataset=dataset,
+            report_dir=Path("/tmp"),
+            ground_truth_column=None,
+            num_repeats=dataset.repeats,
         )
 
     @pytest.mark.unit

--- a/tests/unit/commands/test_benchmark.py
+++ b/tests/unit/commands/test_benchmark.py
@@ -37,6 +37,7 @@ from inference_endpoint.config.runtime_settings import RuntimeSettings
 from inference_endpoint.config.schema import (
     BenchmarkConfig,
     DatasetType,
+    DrainConfig,
     LoadPattern,
     LoadPatternType,
     OfflineSettings,
@@ -475,6 +476,56 @@ settings:
         assert warmup.n_requests is None
 
 
+class TestDrainConfig:
+    """Tests for DrainConfig schema model."""
+
+    @pytest.mark.unit
+    def test_defaults(self):
+        cfg = DrainConfig()
+        assert cfg.warmup_timeout_s == 240.0
+        assert cfg.performance_timeout_s == 240.0
+        assert cfg.accuracy_timeout_s is None
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "field",
+        ["warmup_timeout_s", "performance_timeout_s", "accuracy_timeout_s"],
+    )
+    @pytest.mark.parametrize("value", [0, -1.0])
+    def test_timeout_must_be_positive_or_none(self, field, value):
+        with pytest.raises(ValidationError):
+            DrainConfig(**{field: value})
+
+    @pytest.mark.unit
+    def test_extra_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            DrainConfig(unknown_field=1)
+
+    @pytest.mark.unit
+    def test_yaml_roundtrip(self, tmp_path):
+        yaml_content = """
+type: "offline"
+model_params:
+  name: "test-model"
+endpoint_config:
+  endpoints: ["http://test:8000"]
+datasets:
+  - path: "test.jsonl"
+settings:
+  drain:
+    warmup_timeout_s: 12.5
+    performance_timeout_s: 30.0
+    accuracy_timeout_s: null
+"""
+        config_file = tmp_path / "drain.yaml"
+        config_file.write_text(yaml_content)
+        config = BenchmarkConfig.from_yaml_file(config_file)
+        drain = config.settings.drain
+        assert drain.warmup_timeout_s == 12.5
+        assert drain.performance_timeout_s == 30.0
+        assert drain.accuracy_timeout_s is None
+
+
 class TestBuildPhases:
     """Tests for _build_phases() in execute.py."""
 
@@ -698,6 +749,44 @@ class TestBuildPhases:
         phases = _build_phases(ctx)
 
         assert phases[1].runtime_settings is base_rt_settings
+
+    @pytest.mark.unit
+    def test_configured_drain_timeouts_propagate_to_phases(
+        self, base_rt_settings, simple_dataset
+    ):
+        config = OfflineConfig(
+            **_OFFLINE_KWARGS,
+            settings=OfflineSettings(
+                drain=DrainConfig(
+                    warmup_timeout_s=7.0,
+                    performance_timeout_s=15.0,
+                    accuracy_timeout_s=45.0,
+                ),
+                warmup=WarmupConfig(enabled=True, drain=True),
+            ),
+        )
+        ctx = self._make_ctx(config, base_rt_settings, simple_dataset)
+        ctx.eval_configs = [self._make_eval_config(simple_dataset)]
+        phases = _build_phases(ctx)
+
+        warmup = next(p for p in phases if p.phase_type == PhaseType.WARMUP)
+        perf = next(p for p in phases if p.phase_type == PhaseType.PERFORMANCE)
+        acc = next(p for p in phases if p.phase_type == PhaseType.ACCURACY)
+        assert warmup.drain_timeout == 7.0
+        assert perf.drain_timeout == 15.0
+        assert acc.drain_timeout == 45.0
+
+    @pytest.mark.unit
+    def test_accuracy_drain_timeout_defaults_to_unbounded(
+        self, base_rt_settings, simple_dataset
+    ):
+        config = OfflineConfig(**_OFFLINE_KWARGS)
+        ctx = self._make_ctx(config, base_rt_settings, simple_dataset)
+        ctx.eval_configs = [self._make_eval_config(simple_dataset)]
+        phases = _build_phases(ctx)
+
+        acc = next(p for p in phases if p.phase_type == PhaseType.ACCURACY)
+        assert acc.drain_timeout is None
 
     @pytest.mark.unit
     def test_warmup_uses_independent_rng_instances(


### PR DESCRIPTION
## What does this PR do?

1. Add DrainConfig that accepts three parameters: drain timeout for warmup/perf/acc phase
2. Update the yaml template and unit tests
3. Update drain timeout settings in vlm so that offline scenario could finish properly

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [x] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [x] Code follows project style
- [x] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
