### PR TITLE
feat: Make harmony loader lazy

### DIFF
--- a/src/inference_endpoint/openai/harmony.py
+++ b/src/inference_endpoint/openai/harmony.py
@@ -80,7 +80,7 @@ class Harmonizer:
         self.tokenizer_name = tokenizer_name
         self._encoding_name = encoding_name
         self._reasoning_effort = reasoning_effort
-        self._conversation_start_date = conversation_start_date
+        self._conversation_start_date = conversation_start_date or datetime.date.today().isoformat()
         self.tokenizer: PreTrainedTokenizer | None = None
         self.encoding: "harmony.HarmonyEncoding | None" = None
         self.system_message: "harmony.SystemContent | None" = None
@@ -89,19 +89,21 @@ class Harmonizer:
         self,
     ) -> "tuple[PreTrainedTokenizer, harmony.HarmonyEncoding, harmony.SystemContent]":
         if self.tokenizer is None:
-            self.tokenizer = self.__class__.get_tokenizer(self.tokenizer_name)
-            self.encoding = self.__class__.get_encoding(self._encoding_name)
+            tokenizer = self.__class__.get_tokenizer(self.tokenizer_name)
+            encoding = self.__class__.get_encoding(self._encoding_name)
 
             _effort = getattr(harmony.ReasoningEffort, self._reasoning_effort.upper())
-            conversation_start_date = self._conversation_start_date
-            if conversation_start_date is None:
-                conversation_start_date = datetime.date.today().isoformat()
 
-            self.system_message = (
+            system_message = (
                 harmony.SystemContent.new()
                 .with_reasoning_effort(_effort)
-                .with_conversation_start_date(conversation_start_date)
+                .with_conversation_start_date(self._conversation_start_date)
             )
+
+            # Assign to instance variables only after all steps succeed to ensure atomicity
+            self.tokenizer = tokenizer
+            self.encoding = encoding
+            self.system_message = system_message
 
         assert self.tokenizer is not None
         assert self.encoding is not None

--- a/src/inference_endpoint/openai/harmony.py
+++ b/src/inference_endpoint/openai/harmony.py
@@ -78,18 +78,35 @@ class Harmonizer:
                 If None, the current date will be used. (Default: None)
         """
         self.tokenizer_name = tokenizer_name
-        self.tokenizer = self.__class__.get_tokenizer(tokenizer_name)
-        self.encoding = self.__class__.get_encoding(encoding_name)
+        self._encoding_name = encoding_name
+        self._reasoning_effort = reasoning_effort
+        self._conversation_start_date = conversation_start_date
+        self.tokenizer: PreTrainedTokenizer | None = None
+        self.encoding: "harmony.HarmonyEncoding | None" = None
+        self.system_message: "harmony.SystemContent | None" = None
 
-        _effort = getattr(harmony.ReasoningEffort, reasoning_effort.upper())
-        if conversation_start_date is None:
-            conversation_start_date = datetime.date.today().isoformat()
+    def _ensure_loaded(
+        self,
+    ) -> "tuple[PreTrainedTokenizer, harmony.HarmonyEncoding, harmony.SystemContent]":
+        if self.tokenizer is None:
+            self.tokenizer = self.__class__.get_tokenizer(self.tokenizer_name)
+            self.encoding = self.__class__.get_encoding(self._encoding_name)
 
-        self.system_message = (
-            harmony.SystemContent.new()
-            .with_reasoning_effort(_effort)
-            .with_conversation_start_date(conversation_start_date)
-        )
+            _effort = getattr(harmony.ReasoningEffort, self._reasoning_effort.upper())
+            conversation_start_date = self._conversation_start_date
+            if conversation_start_date is None:
+                conversation_start_date = datetime.date.today().isoformat()
+
+            self.system_message = (
+                harmony.SystemContent.new()
+                .with_reasoning_effort(_effort)
+                .with_conversation_start_date(conversation_start_date)
+            )
+
+        assert self.tokenizer is not None
+        assert self.encoding is not None
+        assert self.system_message is not None
+        return self.tokenizer, self.encoding, self.system_message
 
     def __call__(self, user_prompt: str, tokenize: bool = True) -> str | list[int]:
         """Convert a user prompt to a Harmony-compatible format.
@@ -103,22 +120,21 @@ class Harmonizer:
         Returns:
             The Harmony-compatible format of the user prompt.
         """
+        tokenizer, encoding, system_message = self._ensure_loaded()
         conv = harmony.Conversation.from_messages(
             [
                 harmony.Message.from_role_and_content(
-                    harmony.Role.SYSTEM, self.system_message
+                    harmony.Role.SYSTEM, system_message
                 ),
                 harmony.Message.from_role_and_content(harmony.Role.USER, user_prompt),
             ]
         )
-        toks = self.encoding.render_conversation_for_completion(
-            conv, harmony.Role.ASSISTANT
-        )
+        toks = encoding.render_conversation_for_completion(conv, harmony.Role.ASSISTANT)
 
         if tokenize:
             return toks
         else:
-            return self.tokenizer.decode(toks, skip_special_tokens=False)
+            return tokenizer.decode(toks, skip_special_tokens=False)
 
     def to_text(self, toks: list[int]) -> str:
         """Convert a tokenized sequence to a string.
@@ -129,7 +145,8 @@ class Harmonizer:
         Returns:
             The string representation of the sequence.
         """
-        return self.tokenizer.decode(toks, skip_special_tokens=False)
+        tokenizer, _, _ = self._ensure_loaded()
+        return tokenizer.decode(toks, skip_special_tokens=False)
 
     def to_tokens(self, text: str) -> list[int]:
         """Convert a string to a tokenized sequence.
@@ -140,4 +157,5 @@ class Harmonizer:
         Returns:
             The tokenized sequence.
         """
-        return self.tokenizer.encode(text, add_special_tokens=True)
+        tokenizer, _, _ = self._ensure_loaded()
+        return tokenizer.encode(text, add_special_tokens=True)

--- a/src/inference_endpoint/openai/harmony.py
+++ b/src/inference_endpoint/openai/harmony.py
@@ -80,7 +80,9 @@ class Harmonizer:
         self.tokenizer_name = tokenizer_name
         self._encoding_name = encoding_name
         self._reasoning_effort = reasoning_effort
-        self._conversation_start_date = conversation_start_date or datetime.date.today().isoformat()
+        self._conversation_start_date = (
+            conversation_start_date or datetime.date.today().isoformat()
+        )
         self.tokenizer: PreTrainedTokenizer | None = None
         self.encoding: "harmony.HarmonyEncoding | None" = None
         self.system_message: "harmony.SystemContent | None" = None

--- a/uv.lock
+++ b/uv.lock
@@ -1490,11 +1490,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?
Make the harmony  load the tokenizer lazily. If just a transform is needed, don't load tokenizer.
<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
