### PR TITLE
chore(deps): relax numpy pin to >=1.26.4 for bfcl-eval compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "transformers==5.5.0",
     # Required by transformers' apply_chat_template
     "jinja2==3.1.6",
-    "numpy==2.4.4",
+    "numpy>=1.26.4",
     "datasets==4.8.4",
     "Pillow==12.2.0",
     "sentencepiece==0.2.1",


### PR DESCRIPTION
bfcl-eval (used in the upcoming BFCL v4 accuracy integration) hard-pins numpy==1.26.4, which is mutually exclusive with our existing top-level numpy==2.4.4 pin and causes pip's resolver to fail when installing the [bfcl] extra.

Relax the top-level pin to a lower bound (>=1.26.4) so pip can satisfy both constraints. Our code paths work with numpy 1.x and 2.x; the only binding constraint comes from bfcl-eval. When [bfcl] is not installed, pip will still resolve the latest numpy.

Note: this is a narrow exception to the AGENTS.md "pin exact versions" rule, driven by an external library's hard pin. If we want to enforce a single resolved version everywhere, the alternative is to pin numpy==1.26.4 (matching bfcl-eval) at the top level.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
