### PR TITLE
feat: accuracy issuer inherits perf concurrency in online mode

### DIFF
--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -465,11 +465,29 @@ def _build_phases(
                 f"Accuracy dataset '{eval_cfg.dataset_name}' is a MultiTurnDataset, "
                 "which is not yet supported for accuracy evaluation."
             )
-        # Accuracy phases run at MAX_THROUGHPUT; inheriting perf_lp (e.g. POISSON)
-        # would silently rate-limit evaluation until a multi-turn accuracy strategy
-        # and QPS-budgeting support are added.
-        acc_load_pattern: LoadPattern | None = LoadPattern(
-            type=LoadPatternType.MAX_THROUGHPUT
+        # When the perf phase runs CONCURRENCY (online), the accuracy phase
+        # mirrors that fixed concurrency so evaluation exercises the endpoint
+        # the same way. Every other pattern keeps MAX_THROUGHPUT — inheriting
+        # POISSON would silently rate-limit evaluation to the perf QPS, which
+        # has no QPS-budgeting support for accuracy yet.
+        perf_lp = ctx.rt_settings.load_pattern
+        acc_load_pattern: LoadPattern | None
+        if perf_lp is not None and perf_lp.type == LoadPatternType.CONCURRENCY:
+            acc_load_pattern = LoadPattern(
+                type=LoadPatternType.CONCURRENCY,
+                target_concurrency=perf_lp.target_concurrency,
+            )
+        else:
+            acc_load_pattern = LoadPattern(type=LoadPatternType.MAX_THROUGHPUT)
+        logger.info(
+            "Accuracy issuer '%s' load mode: %s%s",
+            eval_cfg.dataset_name,
+            acc_load_pattern.type.value,
+            (
+                f" (target_concurrency={acc_load_pattern.target_concurrency})"
+                if acc_load_pattern.type == LoadPatternType.CONCURRENCY
+                else ""
+            ),
         )
         acc_settings = RuntimeSettings(
             metric_target=ctx.rt_settings.metric_target,

--- a/tests/unit/commands/test_benchmark.py
+++ b/tests/unit/commands/test_benchmark.py
@@ -16,6 +16,8 @@
 """Tests for benchmark CLI models, config building, and command handlers."""
 
 import asyncio
+import dataclasses
+import logging
 import random
 import tempfile
 from pathlib import Path
@@ -966,6 +968,85 @@ class TestBuildPhases:
 
         acc = next(p for p in phases if p.phase_type == PhaseType.ACCURACY)
         assert acc.drain_timeout is None
+
+    @pytest.mark.unit
+    def test_accuracy_phase_inherits_perf_concurrency(
+        self, base_rt_settings, simple_dataset
+    ):
+        """When the perf phase runs CONCURRENCY, the accuracy phase mirrors the
+        same fixed concurrency instead of bursting at MAX_THROUGHPUT."""
+        rt = dataclasses.replace(
+            base_rt_settings,
+            load_pattern=LoadPattern(
+                type=LoadPatternType.CONCURRENCY, target_concurrency=7
+            ),
+        )
+        config = OfflineConfig(**_OFFLINE_KWARGS)
+        ctx = self._make_ctx(config, rt, simple_dataset)
+        ctx.eval_configs = [self._make_eval_config(simple_dataset)]
+        phases = _build_phases(ctx)
+
+        acc = next(p for p in phases if p.phase_type == PhaseType.ACCURACY)
+        assert acc.runtime_settings.load_pattern is not None
+        assert acc.runtime_settings.load_pattern.type == LoadPatternType.CONCURRENCY
+        assert acc.runtime_settings.load_pattern.target_concurrency == 7
+
+    @pytest.mark.unit
+    def test_accuracy_phase_max_throughput_when_perf_poisson(
+        self, base_rt_settings, simple_dataset
+    ):
+        """POISSON perf must not rate-limit accuracy: it stays MAX_THROUGHPUT."""
+        rt = dataclasses.replace(
+            base_rt_settings,
+            load_pattern=LoadPattern(type=LoadPatternType.POISSON, target_qps=10.0),
+        )
+        config = OfflineConfig(**_OFFLINE_KWARGS)
+        ctx = self._make_ctx(config, rt, simple_dataset)
+        ctx.eval_configs = [self._make_eval_config(simple_dataset)]
+        phases = _build_phases(ctx)
+
+        acc = next(p for p in phases if p.phase_type == PhaseType.ACCURACY)
+        assert acc.runtime_settings.load_pattern is not None
+        assert acc.runtime_settings.load_pattern.type == LoadPatternType.MAX_THROUGHPUT
+
+    @pytest.mark.unit
+    def test_accuracy_phase_max_throughput_when_perf_offline(
+        self, base_rt_settings, simple_dataset
+    ):
+        """Offline (MAX_THROUGHPUT) perf leaves accuracy at MAX_THROUGHPUT."""
+        config = OfflineConfig(**_OFFLINE_KWARGS)
+        ctx = self._make_ctx(config, base_rt_settings, simple_dataset)
+        ctx.eval_configs = [self._make_eval_config(simple_dataset)]
+        phases = _build_phases(ctx)
+
+        acc = next(p for p in phases if p.phase_type == PhaseType.ACCURACY)
+        assert acc.runtime_settings.load_pattern is not None
+        assert acc.runtime_settings.load_pattern.type == LoadPatternType.MAX_THROUGHPUT
+
+    @pytest.mark.unit
+    def test_accuracy_issuer_logs_load_mode(
+        self, base_rt_settings, simple_dataset, caplog
+    ):
+        """The accuracy issuer logs which load mode it will run in."""
+        rt = dataclasses.replace(
+            base_rt_settings,
+            load_pattern=LoadPattern(
+                type=LoadPatternType.CONCURRENCY, target_concurrency=4
+            ),
+        )
+        config = OfflineConfig(**_OFFLINE_KWARGS)
+        ctx = self._make_ctx(config, rt, simple_dataset)
+        ctx.eval_configs = [self._make_eval_config(simple_dataset)]
+
+        with caplog.at_level(
+            logging.INFO, logger="inference_endpoint.commands.benchmark.execute"
+        ):
+            _build_phases(ctx)
+
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any(
+            "load mode" in m and "concurrency" in m and "4" in m for m in msgs
+        ), msgs
 
     @pytest.mark.unit
     def test_warmup_uses_independent_rng_instances(


### PR DESCRIPTION
## What

When the performance phase runs the **CONCURRENCY** load pattern (online mode), the accuracy phase now mirrors that same fixed concurrency instead of always bursting at `MAX_THROUGHPUT`. This makes accuracy evaluation exercise the endpoint the same way the performance run does.

## Behavior

| Perf load pattern | Accuracy phase (before) | Accuracy phase (after) |
| --- | --- | --- |
| `concurrency` (online) | `max_throughput` | **`concurrency` (same `target_concurrency`)** |
| `poisson` (online) | `max_throughput` | `max_throughput` (unchanged) |
| `max_throughput` (offline) | `max_throughput` | `max_throughput` (unchanged) |

`POISSON` and offline `MAX_THROUGHPUT` deliberately keep the accuracy phase at `MAX_THROUGHPUT` — inheriting `POISSON` would silently rate-limit evaluation to the perf QPS, and there's no accuracy QPS-budgeting yet. The gate is purely `load_pattern.type == CONCURRENCY`, which the schema already constrains to online mode (`schema.py`), so no separate test-type check is needed.

The accuracy issuer also now logs its chosen load mode per accuracy dataset, e.g.:

```
Accuracy issuer 'aime' load mode: concurrency (target_concurrency=64)
```

## Scope

- Localized to `_build_phases()` in `commands/benchmark/execute.py` (runs once at setup — no hot-path impact).
- No schema/CLI/template changes (automatic behavior, no new flag).

## Tests

Added to the existing `TestBuildPhases` suite in `tests/unit/commands/test_benchmark.py`:
- `test_accuracy_phase_inherits_perf_concurrency` — perf `concurrency(7)` → accuracy `concurrency`, `target_concurrency == 7`
- `test_accuracy_phase_max_throughput_when_perf_poisson` — perf `poisson` → accuracy stays `max_throughput`
- `test_accuracy_phase_max_throughput_when_perf_offline` — offline → accuracy stays `max_throughput`
- `test_accuracy_issuer_logs_load_mode` — asserts the issuer logs its mode

Verification: `tests/unit/commands` + `tests/unit/load_generator` → **266 passed**; `pre-commit` (ruff, ruff-format, mypy, license) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)