### PR TITLE
fix(openai): capture vLLM `reasoning` field on the non-streaming path

### DIFF
--- a/src/inference_endpoint/openai/openai_msgspec_adapter.py
+++ b/src/inference_endpoint/openai/openai_msgspec_adapter.py
@@ -213,8 +213,12 @@ class OpenAIMsgspecAdapter(HttpRequestAdapter):
             metadata["finish_reason"] = choice.finish_reason
         if choice.message.tool_calls:
             metadata["tool_calls"] = choice.message.tool_calls
-        if choice.message.reasoning_content:
-            metadata["reasoning_content"] = choice.message.reasoning_content
+        # vLLM emits the reasoning trace under `reasoning`; sglang/DeepSeek under
+        # `reasoning_content`. Fall back so metadata carries it for both engines
+        # (mirrors the TextModelOutput.reasoning fallback below).
+        reasoning_trace = choice.message.reasoning_content or choice.message.reasoning
+        if reasoning_trace:
+            metadata["reasoning_content"] = reasoning_trace
 
         tool_calls_tuple = (
             tuple(choice.message.tool_calls) if choice.message.tool_calls else None
@@ -223,7 +227,7 @@ class OpenAIMsgspecAdapter(HttpRequestAdapter):
             id=result_id or response.id,
             response_output=TextModelOutput(
                 output=choice.message.content or "",
-                reasoning=choice.message.reasoning_content,
+                reasoning=choice.message.reasoning_content or choice.message.reasoning,
                 tool_calls=tool_calls_tuple,
             ),
             metadata=metadata,

--- a/src/inference_endpoint/openai/types.py
+++ b/src/inference_endpoint/openai/types.py
@@ -150,6 +150,7 @@ class ChatCompletionResponseMessage(
     refusal: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
     reasoning_content: str | None = None
+    reasoning: str | None = None  # vLLM field name
 
 
 class ChatCompletionChoice(


### PR DESCRIPTION
vLLM's reasoning missing from the output due to the non-streaming ChatCompletionResponseMessage struct declared only `reasoning_content` (the SGLang/DeepSeek field name), so msgspec dropped vLLM's reasoning trace (emitted under the `reasoning` key) at decode.

`reasoning_content` has been deprecated by vLLM via this RFC: https://github.com/vllm-project/vllm/issues/27755
and this PR removes `reasoning_content` support in vLLM: https://github.com/vllm-project/vllm/pull/33402

Effect: TextModelOutput.reasoning was None for vLLM servers, so OSL tokenization (which joins reasoning + content + tool_calls via __str__) counted only content -> vLLM mean-OSL/turn + out-tok/s undercounted ~2.4x (the ~4.7M uncounted reasoning tokens ~= sglang's total-over-content delta). 

Changes:
  - types.py: ChatCompletionResponseMessage += reasoning: str | None
  - openai_msgspec_adapter.py: reasoning=reasoning_content OR reasoning

The streaming path already does the equivalent; this is the non-streaming parity. 

The correct way to call `reasoning` as documented by vLLM: https://docs.vllm.ai/en/latest/examples/reasoning/openai_chat_completion_tool_calls_with_reasoning/ 

## Type of change

- [ x ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup
