### PR TITLE
feat(report): record run_config (seeds + load/warmup) in result_summary.json

### DIFF
--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -1110,16 +1110,28 @@ async def _run_benchmark_async(
 
                 if snap_dict is not None:
                     try:
-                        runtime = ctx.config.settings.runtime
-                        warmup = ctx.config.settings.warmup
                         load_pattern = ctx.config.settings.load_pattern
+                        runtime_cfg = ctx.config.settings.runtime
+                        # load_pattern + warmup config and the RNG seeds, so
+                        # result_summary.json is self-describing and a valid run is
+                        # identified by its settings. The full, re-runnable config
+                        # lives in config.yaml alongside. The resolved/effective
+                        # runtime settings (sample count + ordering, which can differ
+                        # per audit phase) are deferred to a follow-up. endpoint_config
+                        # (api_key/URLs) is a sibling of settings and never included,
+                        # so no secrets.
+                        run_config = ctx.config.settings.model_dump(
+                            mode="json", include={"load_pattern", "warmup"}
+                        )
+                        run_config["scheduler_random_seed"] = (
+                            runtime_cfg.scheduler_random_seed
+                        )
+                        run_config["dataloader_random_seed"] = (
+                            runtime_cfg.dataloader_random_seed
+                        )
                         report = Report.from_snapshot(
                             snap_dict,
-                            seeds={
-                                "scheduler_random_seed": runtime.scheduler_random_seed,
-                                "dataloader_random_seed": runtime.dataloader_random_seed,
-                                "warmup_random_seed": warmup.warmup_random_seed,
-                            },
+                            run_config=run_config,
                             use_legacy_loadgen_qps_metrics=(
                                 load_pattern.type == LoadPatternType.POISSON
                                 and load_pattern.use_legacy_loadgen_qps_metrics

--- a/src/inference_endpoint/metrics/report.py
+++ b/src/inference_endpoint/metrics/report.py
@@ -146,25 +146,28 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
     qps: float | None = None
     tps: float | None = None
 
-    # RNG seeds for this run (scheduler/dataloader/warmup, from config). Carried
-    # so result_summary.json is self-validating: a reproducible run is identified
-    # by its seeds. These are config, not a measured metric, so the from_snapshot
-    # caller supplies them rather than reading them from the metrics snapshot.
-    seeds: dict[str, int] | None = None
+    # Run configuration (load_pattern, warmup, and the scheduler/dataloader RNG
+    # seeds), from config. Carried so result_summary.json is self-describing and a
+    # valid run is identified by its settings. Config, not a measured metric, so
+    # the from_snapshot caller supplies it rather than reading it from the metrics
+    # snapshot. (Resolved/effective runtime settings — sample count + ordering,
+    # which can differ per audit phase — are deferred to a follow-up.)
+    run_config: dict[str, Any] | None = None
 
     @classmethod
     def from_snapshot(
         cls,
         snap: dict[str, Any],
         *,
-        seeds: dict[str, int] | None = None,
+        run_config: dict[str, Any] | None = None,
         use_legacy_loadgen_qps_metrics: bool = True,
     ) -> Report:
         """Build a Report from a snapshot dict.
 
-        ``seeds`` (optional) carries the run's RNG seeds from config into the
-        report so result_summary.json is self-validating; it is keyword-only
-        because it is config, not part of the metrics snapshot.
+        ``run_config`` (optional, keyword-only) carries the run's configuration
+        (load_pattern, warmup, and the scheduler/dataloader RNG seeds) into the
+        report so result_summary.json is self-describing; it is config, not part
+        of the metrics snapshot.
 
         Input is the dict form produced by
         ``inference_endpoint.async_utils.services.metrics_aggregator.snapshot
@@ -274,7 +277,7 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
             legacy_loadgen_window_duration_ns=legacy_loadgen_window_duration_ns,
             qps=qps,
             tps=tps,
-            seeds=seeds,
+            run_config=run_config,
         )
 
     def to_json(self, save_to: os.PathLike | None = None) -> bytes:
@@ -304,9 +307,14 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
         fn(f"Version: {self.version}{newline}")
         if self.git_sha:
             fn(f"Git SHA: {self.git_sha}{newline}")
-        if self.seeds:
-            seed_str = ", ".join(f"{k}={v}" for k, v in self.seeds.items())
-            fn(f"Seeds: {seed_str}{newline}")
+        if self.run_config:
+            fn(f"Run config:{newline}")
+            for section, params in self.run_config.items():
+                if isinstance(params, dict):
+                    inner = ", ".join(f"{k}={v}" for k, v in params.items())
+                    fn(f"  {section}: {inner}{newline}")
+                else:
+                    fn(f"  {section}: {params}{newline}")
         if self.test_started_at > 0:
             approx = monotime_to_datetime(self.test_started_at)
             fn(f"Test started at: {approx.strftime('%Y-%m-%d %H:%M:%S')}{newline}")

--- a/tests/unit/metrics/test_report_builder.py
+++ b/tests/unit/metrics/test_report_builder.py
@@ -181,16 +181,23 @@ class TestFromSnapshot:
         # OSL data was written → tps is computable.
         assert report.tps is not None
 
-    def test_seeds_keyword_only_passthrough(self):
-        """seeds is config, not a snapshot metric: None unless the caller
+    def test_run_config_keyword_only_passthrough(self):
+        """run_config is config, not a snapshot metric: None unless the caller
         supplies it, and carried verbatim into the report when it does."""
         registry = _make_registry(n_samples=5)
         snap = snapshot_to_dict(
             registry.build_snapshot(state=SessionState.COMPLETE, n_pending_tasks=0)
         )
-        assert Report.from_snapshot(snap).seeds is None
-        seeds = {"scheduler_random_seed": 42, "dataloader_random_seed": 7}
-        assert Report.from_snapshot(snap, seeds=seeds).seeds == seeds
+        assert Report.from_snapshot(snap).run_config is None
+        run_config = {
+            "load_pattern": {"type": "poisson", "target_qps": 14.75},
+            "warmup": {"enabled": False, "warmup_random_seed": 42},
+            "scheduler_random_seed": 42,
+            "dataloader_random_seed": 42,
+        }
+        assert (
+            Report.from_snapshot(snap, run_config=run_config).run_config == run_config
+        )
 
     def test_failed_uses_tracked_counter(self):
         """``n_samples_failed`` reads from ``tracked_samples_failed``, not
@@ -279,23 +286,28 @@ class TestReportDisplayAndSerialize:
         assert data["qps"] is None
         assert data["tps"] is None
 
-    def test_to_json_serializes_seeds(self):
-        """result_summary.json carries the run's RNG seeds so a run can be
-        validated as reproducible; absent seeds serialize as null."""
+    def test_to_json_and_display_carry_run_config(self):
+        """result_summary.json + report.txt carry the run's config so a run is
+        self-describing/reproducible; absent run_config serializes as null."""
         registry = _make_registry(n_samples=5)
         snap = snapshot_to_dict(
             registry.build_snapshot(state=SessionState.COMPLETE, n_pending_tasks=0)
         )
-        seeds = {"scheduler_random_seed": 42, "dataloader_random_seed": 42}
-        report = Report.from_snapshot(snap, seeds=seeds)
-        assert json.loads(report.to_json())["seeds"] == seeds
+        run_config = {
+            "load_pattern": {"type": "poisson", "target_qps": 14.75},
+            "scheduler_random_seed": 42,
+            "dataloader_random_seed": 42,
+        }
+        report = Report.from_snapshot(snap, run_config=run_config)
+        assert json.loads(report.to_json())["run_config"] == run_config
 
         lines: list[str] = []
         report.display(fn=lines.append, summary_only=True)
-        assert any("Seeds:" in ln for ln in lines)
+        assert any("Run config:" in ln for ln in lines)
+        assert any("load_pattern:" in ln and "poisson" in ln for ln in lines)
 
-        # Absent seeds -> null, not omitted.
-        assert json.loads(Report.from_snapshot(snap).to_json())["seeds"] is None
+        # Absent run_config -> null, not omitted.
+        assert json.loads(Report.from_snapshot(snap).to_json())["run_config"] is None
 
     def test_to_json_save(self, tmp_path: Path):
         registry = _make_registry(n_samples=5)


### PR DESCRIPTION
## Summary
Record the run's **load config + RNG seeds** in the benchmark report so a run is self-describing and validatable from its own `result_summary.json` (and `report.txt`).

A single `run_config` field on `Report` carries:
- `load_pattern` (type / target_qps / concurrency / `use_legacy_loadgen_qps_metrics` — needed to interpret qps/tps),
- `warmup` (incl. `warmup_random_seed`),
- `scheduler_random_seed` + `dataloader_random_seed`.

`load_pattern` / `warmup` come from `settings.model_dump(include={"load_pattern", "warmup"})`; the seeds are read off `settings.runtime`. `endpoint_config` (api_key / endpoint URLs) is a **sibling** of `settings` and never included, so no secrets leak. The full, re-runnable config still lives in `config.yaml` alongside.

**Replaces the standalone `seeds` field (#353)**: the RNG seeds now live under `run_config`.

> **Scope note:** the *resolved / effective* runtime settings (the actual issued sample count and sample ordering, which can differ **per audit phase** — e.g. MLPerf TEST04's fixed-sample output-caching phase) are intentionally **left to a follow-up PR**. Getting those right means sourcing from the live `rt_settings` per phase, which is a separate change. This PR only records the static, run-identifying config above.

## Example `result_summary.json`
From a real **DGX-B300x8 DeepSeek-R1 server (poisson)** run — `qps`/`tps` stay top-level, run config under `run_config` (metric dicts elided as `{ ... }`):
```jsonc
{
  "version": "0.1.0",
  "git_sha": "...",
  "n_samples_completed": 40000,
  "duration_ns": 3328465383747,
  "state": "complete",
  "complete": true,
  "ttft": { ... }, "tpot": { ... }, "latency": { ... }, "output_sequence_lengths": { ... },
  "legacy_loadgen_window_duration_ns": 2753346633148,
  "qps": 14.53,
  "tps": 54489.98,
  "run_config":
  {
    "load_pattern": {
      "type": "poisson",
      "target_qps": 14.75,
      "target_concurrency": null,
      "use_legacy_loadgen_qps_metrics": true
    },
    "warmup": {
      "enabled": false,
      "n_requests": null,
      "salt": true,
      "drain": false,
      "warmup_random_seed": 42
    },
    "scheduler_random_seed": 42,
    "dataloader_random_seed": 42
  }
}
```
Same, rendered in `report.txt`:
```
Run config:
  load_pattern: type=poisson, target_qps=14.75, target_concurrency=None, use_legacy_loadgen_qps_metrics=True
  warmup: enabled=False, n_requests=None, salt=True, drain=False, warmup_random_seed=42
  scheduler_random_seed: 42
  dataloader_random_seed: 42
```

## Tests
- `run_config` keyword-only passthrough; serialization + `report.txt` rendering; absent -> `null`.

Rebased on latest `main` (keeps PR #372's `use_legacy_loadgen_qps_metrics`; git_sha handled by #398).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
