### PR TITLE
chore(readme): add Tests, Codecov, and Ruff badges

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,14 @@ jobs:
             coverage.xml
             htmlcov/
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # MLPerf Inference Endpoint Benchmarking System
 
+[![Tests](https://github.com/mlcommons/endpoints/actions/workflows/test.yml/badge.svg)](https://github.com/mlcommons/endpoints/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/mlcommons/endpoints/branch/main/graph/badge.svg)](https://codecov.io/gh/mlcommons/endpoints)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen.svg)](https://pre-commit.com/)
 
 A high-performance benchmarking tool for LLM inference endpoints, targeting 50k+ QPS. Part of [MLCommons](https://mlcommons.org/).


### PR DESCRIPTION
## What

Adds status/quality badges to the README and wires coverage reporting:

- **Tests** — live CI status badge for `test.yml`.
- **codecov** — coverage badge. `test.yml` already generated `coverage.xml` but nothing consumed it; this adds a `codecov/codecov-action` upload step (SHA-pinned, `fail_ci_if_error: false` so it never blocks CI).
- **Ruff** — code-style badge (the repo lints/formats with ruff).
- Keeps existing License / Python 3.12+ / Pre-commit badges.

## Notes

- The **codecov badge populates once the Codecov app is enabled for `mlcommons/endpoints`**. For a public repo, tokenless upload works; if the org prefers a token, add a `CODECOV_TOKEN` repo secret (the step already references it).
- No coverage badge was possible before because no workflow uploaded coverage anywhere.
- CodeQL is configured via GitHub default code-scanning setup (no committed workflow file), so it isn't badge-able via `actions/workflows/*.yml/badge.svg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)