### PR TITLE
fix: dont discount open tcp-ports against max-connections on init

### DIFF
--- a/src/inference_endpoint/endpoint_client/config.py
+++ b/src/inference_endpoint/endpoint_client/config.py
@@ -44,7 +44,7 @@ from .cpu_affinity import (
     get_cpus_in_numa_node,
     get_current_numa_node,
 )
-from .utils import get_ephemeral_port_limit, get_ephemeral_port_range
+from .utils import get_ephemeral_port_range
 
 
 def _endpoint_destination(url: str) -> tuple[str | None, int]:
@@ -267,20 +267,17 @@ class HTTPClientConfig(WithUpdatesMixin, BaseModel):
         if self.endpoint_urls:
             low, high = get_ephemeral_port_range()
             system_maximum_ports = high - low + 1
-            available_ports = get_ephemeral_port_limit()
 
-            # The ephemeral-port limit is per (source IP, destination) pair: the
+            # Ephemeral-port capacity is per (source IP, destination) pair: the
             # TCP 4-tuple (src_ip, src_port, dst_ip, dst_port) only needs to be
             # unique, so the kernel reuses local ports across distinct
             # destinations. Each distinct endpoint therefore has its own
-            # ~`available_ports` budget. Workers are round-robined across
-            # endpoints, so scale the cap by the distinct-endpoint count;
-            # otherwise concurrency is needlessly throttled to a single
-            # endpoint's budget when several endpoints are configured.
+            # configured port-range budget. Do not subtract live, process-global
+            # socket occupancy: it includes unrelated destinations and is racy.
             distinct_endpoints = len(
                 {_endpoint_destination(u) for u in self.endpoint_urls}
             )
-            port_budget = available_ports * max(1, distinct_endpoints)
+            port_budget = system_maximum_ports * max(1, distinct_endpoints)
 
             if self.max_connections == -1:
                 object.__setattr__(self, "max_connections", port_budget)
@@ -288,7 +285,7 @@ class HTTPClientConfig(WithUpdatesMixin, BaseModel):
                 if self.max_connections > port_budget:
                     raise RuntimeError(
                         f"--max-connections ({self.max_connections}) exceeds the ephemeral "
-                        f"port budget ({port_budget} = {available_ports} ports x "
+                        f"port budget ({port_budget} = {system_maximum_ports} ports x "
                         f"{max(1, distinct_endpoints)} distinct endpoint(s)). Reduce "
                         f"--max-connections, add endpoints, or raise the system port range."
                     )

--- a/tests/unit/async_utils/services/metrics_aggregator/test_token_metrics.py
+++ b/tests/unit/async_utils/services/metrics_aggregator/test_token_metrics.py
@@ -16,9 +16,11 @@
 """Tests for BatchTokenizer and TokenBatchQueue."""
 
 import asyncio
+import multiprocessing
 import time
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+from multiprocessing.connection import wait as wait_for_process
 from unittest.mock import patch
 
 import pytest
@@ -707,16 +709,45 @@ def test_terminate_procs_kills_running_workers():
     to ``None``, so the worker handles must be snapshotted BEFORE shutdown — a
     blocked worker is only killed if terminate() actually runs.
     """
-    ex = ProcessPoolExecutor(max_workers=1)
-    ex.submit(time.sleep, 30)  # occupy the worker so it won't exit on its own
-    deadline = time.monotonic() + 5
-    while not getattr(ex, "_processes", None) and time.monotonic() < deadline:
-        time.sleep(0.01)
-    procs = list((getattr(ex, "_processes", None) or {}).values())
-    assert procs, "worker did not spawn"
+    ex = ProcessPoolExecutor(
+        max_workers=1, mp_context=multiprocessing.get_context("spawn")
+    )
+    procs = []
+    manager_thread = None
+    try:
+        ex.submit(time.sleep, 0).result(timeout=30)
+        future = ex.submit(time.sleep, 30)
+        manager_thread = getattr(ex, "_executor_manager_thread", None)
+        deadline = time.monotonic() + 5
+        while (
+            not future.running() and not future.done() and time.monotonic() < deadline
+        ):
+            time.sleep(0.01)
+        if future.done():
+            future.result()
+        assert future.running(), "worker task did not start"
+        procs = list((getattr(ex, "_processes", None) or {}).values())
+        assert procs, "worker did not spawn"
+        assert not wait_for_process(
+            [p.sentinel for p in procs], timeout=0
+        ), "worker exited before termination"
 
-    _terminate_procs([ex])
+        _terminate_procs([ex])
 
-    for p in procs:
-        p.join(5)
-        assert not p.is_alive(), "worker was not terminated"
+        for p in procs:
+            # The executor manager may reap the child concurrently; sentinel
+            # readiness observes exit without racing its return-code update.
+            assert wait_for_process(
+                [p.sentinel], timeout=5
+            ), "worker was not terminated"
+    finally:
+        cleanup_procs = procs or list((getattr(ex, "_processes", None) or {}).values())
+        for p in cleanup_procs:
+            if not wait_for_process([p.sentinel], timeout=0):
+                try:
+                    p.kill()
+                except (OSError, ValueError):
+                    pass
+        ex.shutdown(wait=False, cancel_futures=True)
+        if manager_thread is not None:
+            manager_thread.join(5)

--- a/tests/unit/endpoint_client/test_http_client_config.py
+++ b/tests/unit/endpoint_client/test_http_client_config.py
@@ -49,16 +49,13 @@ class TestAutoNumWorkersNonLinux:
 class TestEndpointBudgetScaling:
     """max_connections budget scales with the number of distinct endpoints.
 
-    The ephemeral-port limit is per (source IP, destination) pair, so each
-    distinct endpoint contributes its own ~available_ports budget. num_workers
+    Ephemeral-port capacity is per (source IP, destination) pair, so each
+    distinct endpoint contributes its configured port-range budget. num_workers
     is pinned (>=1) so config resolution skips the NUMA auto-probe.
     """
 
     def test_auto_budget_scales_with_distinct_endpoints(self):
-        with (
-            patch.object(cfg, "get_ephemeral_port_range", return_value=(32768, 60999)),
-            patch.object(cfg, "get_ephemeral_port_limit", return_value=10000),
-        ):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
             c = cfg.HTTPClientConfig(
                 endpoint_urls=[
                     "http://10.0.0.1:8000",
@@ -70,22 +67,31 @@ class TestEndpointBudgetScaling:
         assert c.max_connections == 30000  # 10000 ports x 3 distinct endpoints
 
     def test_single_endpoint_budget_unchanged(self):
-        with (
-            patch.object(cfg, "get_ephemeral_port_range", return_value=(32768, 60999)),
-            patch.object(cfg, "get_ephemeral_port_limit", return_value=10000),
-        ):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
             c = cfg.HTTPClientConfig(
                 endpoint_urls=["http://10.0.0.1:8000"], num_workers=10
             )
         assert c.max_connections == 10000  # single endpoint -> unchanged
 
+    def test_live_socket_usage_does_not_reject_overall_connection_limit(self):
+        with (
+            patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)),
+            patch.object(
+                cfg, "get_ephemeral_port_limit", return_value=0, create=True
+            ) as live_port_limit,
+        ):
+            c = cfg.HTTPClientConfig(
+                endpoint_urls=["http://10.0.0.1:8000"],
+                num_workers=10,
+                max_connections=10,
+            )
+        assert c.max_connections == 10
+        live_port_limit.assert_not_called()
+
     def test_duplicate_endpoints_do_not_inflate_budget(self):
         # Same (host, port) repeated (even with different paths) is one
         # destination -> one budget, since the 4-tuple ignores path.
-        with (
-            patch.object(cfg, "get_ephemeral_port_range", return_value=(32768, 60999)),
-            patch.object(cfg, "get_ephemeral_port_limit", return_value=10000),
-        ):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
             c = cfg.HTTPClientConfig(
                 endpoint_urls=[
                     "http://10.0.0.1:8000/v1/a",
@@ -98,10 +104,7 @@ class TestEndpointBudgetScaling:
 
     def test_explicit_max_connections_within_scaled_budget_ok(self):
         # 25000 exceeds one endpoint's budget (10000) but fits 3 (30000).
-        with (
-            patch.object(cfg, "get_ephemeral_port_range", return_value=(32768, 60999)),
-            patch.object(cfg, "get_ephemeral_port_limit", return_value=10000),
-        ):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
             c = cfg.HTTPClientConfig(
                 endpoint_urls=[
                     "http://10.0.0.1:8000",
@@ -114,10 +117,7 @@ class TestEndpointBudgetScaling:
         assert c.max_connections == 25000
 
     def test_explicit_max_connections_exceeding_scaled_budget_raises(self):
-        with (
-            patch.object(cfg, "get_ephemeral_port_range", return_value=(32768, 60999)),
-            patch.object(cfg, "get_ephemeral_port_limit", return_value=10000),
-        ):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
             with pytest.raises(RuntimeError, match="exceeds the ephemeral"):
                 cfg.HTTPClientConfig(
                     endpoint_urls=["http://10.0.0.1:8000", "http://10.0.0.2:8000"],
@@ -156,10 +156,7 @@ class TestEndpointDestination:
         assert len(keys) == 2
 
     def test_schemeless_budget_scales_with_distinct_hosts(self):
-        with (
-            patch.object(cfg, "get_ephemeral_port_range", return_value=(32768, 60999)),
-            patch.object(cfg, "get_ephemeral_port_limit", return_value=10000),
-        ):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
             c = cfg.HTTPClientConfig(
                 endpoint_urls=["10.0.0.1:8000", "10.0.0.2:8000"],
                 num_workers=10,


### PR DESCRIPTION
## Problem

This fixes false ephemeral-port budget failures when running the test suite in parallel with `pytest -n auto`.

During a large parallel test run, client setup failed with:

```text
--max-connections (10) exceeds the ephemeral port budget (0 = 0 ports x 1 distinct endpoint(s))
```

The client was counting every socket currently open on the machine. Sockets created by other tests made that count reach the system port-range size, so setup incorrectly concluded that no ports remained.

[#371](https://github.com/mlcommons/endpoints/pull/371) / [commit `72c28e0`](https://github.com/mlcommons/endpoints/commit/72c28e0d8d336623d247d9b1a9d8bb6b0535d7b5) correctly gave each distinct endpoint its own budget, but it still started from this changing machine-wide socket count. If that count reported zero available ports, endpoint scaling could not help.

## Fix

Use the configured OS ephemeral-port range as the stable overall budget instead of subtracting sockets that happen to be open during setup. Continue multiplying that budget by the number of distinct endpoints.

If the machine actually runs out of ports later, the connection attempt will report the real runtime error.

## Unchanged behavior

- `max_connections` remains one overall limit.
- `warmup_connections` remains one overall limit.
- Existing worker pool splitting is unchanged.
- CLI defaults and pytest configuration are unchanged.

## CI follow-up

The first PR run exposed an unrelated race in `test_terminate_procs_kills_running_workers`. The worker had exited via SIGTERM, but the test thread and `ProcessPoolExecutor` manager thread raced to reap it. The losing `waitpid()` call saw `ECHILD`, so `Process.is_alive()` briefly returned `True` even though the failure output already showed `exitcode=-SIGTERM`.

[Commit `b084d6b7`](https://github.com/mlcommons/endpoints/commit/b084d6b729530e33ae187fe2fe25c54902b0a972) makes the test observe the process sentinel instead of racing process return-code bookkeeping. It also uses the production `spawn` context, a stdlib-only warm worker probe, and direct cleanup on failure. Production shutdown behavior is unchanged.

## Validation

- Regression test reproduced the exact zero-budget error before the fix and passes afterward.
- HTTP client config tests: `19 passed`.
- Metrics aggregator token tests: `50 passed`.
- Unit-marked suite: `946 passed, 5 skipped`.
- Full non-slow suite passes with `pytest -q -n auto -x -m "not slow and not performance"`.
- Reported warmup and preexisting-dead-worker integration cases passed.
- All pre-commit checks passed.
- GitHub Actions `test`, schema, build, audit, pre-commit, CodeQL, and CLA checks pass.

The separately marked slow 32-worker test still reaches its existing 60-second startup timeout. This PR does not change that separate behavior.
