### PR TITLE
feat: Add worker id to logs

### DIFF
--- a/src/inference_endpoint/core/record.py
+++ b/src/inference_endpoint/core/record.py
@@ -157,6 +157,7 @@ class EventRecord(msgspec.Struct, kw_only=True, frozen=True, gc=False):  # type:
     turn: int | None = None
     data: OUTPUT_TYPE | PromptData | ErrorData | None = None
     finish_reason: str | msgspec.UnsetType = msgspec.UNSET
+    worker_id: int | msgspec.UnsetType = msgspec.UNSET
 
 
 class EventRecordCodec:

--- a/src/inference_endpoint/endpoint_client/worker.py
+++ b/src/inference_endpoint/endpoint_client/worker.py
@@ -433,7 +433,7 @@ class Worker:
         self._pool.release(conn)
 
         # Send final complete back to main rank
-        self._responses.send(accumulator.get_final_output())
+        self._responses.send(self._with_worker_id(accumulator.get_final_output()))
 
     @profile
     async def _handle_non_streaming_body(self, req: InFlightRequest) -> None:
@@ -451,7 +451,7 @@ class Worker:
         result = self._adapter.decode_response(response_bytes, query_id)
 
         # Send result back to main rank
-        self._responses.send(result)
+        self._responses.send(self._with_worker_id(result))
 
     async def _handle_error(self, query_id: str, error: Exception | str) -> None:
         """Send error response for a query."""
@@ -469,9 +469,23 @@ class Worker:
         error_response = QueryResult(
             id=query_id,
             response_output=None,
+            metadata={"worker_id": self.worker_id},
             error=error_data,
         )
         self._responses.send(error_response)
+
+    def _with_worker_id(self, result: QueryResult) -> QueryResult:
+        """Rebuild QueryResult with worker_id in metadata (adapters are worker-agnostic)."""
+        # Build a new struct with a fresh metadata dict instead of mutating the
+        # existing one in place: QueryResult is frozen and gc=False, and its
+        # contract requires metadata to stay unmutated after construction (see the
+        # AT-RISK note in core/types.py) so gc=False stays safe.
+        return QueryResult(
+            id=result.id,
+            response_output=result.response_output,
+            metadata={**result.metadata, "worker_id": self.worker_id},
+            error=result.error,
+        )
 
     @profile
     async def _iter_sse_lines(

--- a/src/inference_endpoint/load_generator/session.py
+++ b/src/inference_endpoint/load_generator/session.py
@@ -604,6 +604,7 @@ class BenchmarkSession:
                 )
             if self._current_phase_type != PhaseType.WARMUP:
                 finish_reason = resp.metadata.get("finish_reason")
+                worker_id = resp.metadata.get("worker_id")
                 self._publisher.publish(
                     EventRecord(
                         event_type=SampleEventType.COMPLETE,
@@ -618,6 +619,9 @@ class BenchmarkSession:
                             finish_reason
                             if isinstance(finish_reason, str)
                             else msgspec.UNSET
+                        ),
+                        worker_id=(
+                            worker_id if isinstance(worker_id, int) else msgspec.UNSET
                         ),
                     )
                 )

--- a/tests/integration/endpoint_client/test_worker.py
+++ b/tests/integration/endpoint_client/test_worker.py
@@ -142,6 +142,7 @@ class TestWorkerBasicFunctionality:
                 assert query_id in final_responses
                 response = final_responses[query_id]
                 assert response.error is None
+                assert response.metadata.get("worker_id") == 0
 
                 if stream:
                     # Streaming response - expected is (first_chunk_content, full_output_tuple)
@@ -293,6 +294,7 @@ class TestWorkerErrorHandling:
             assert isinstance(response, QueryResult)
             assert response.id == query_id
             assert response.error is not None
+            assert response.metadata.get("worker_id") == 0
             error_str = str(response.error)
             error_lower = error_str.lower()
             assert (
@@ -363,6 +365,7 @@ class TestWorkerErrorHandling:
             assert isinstance(response, QueryResult)
             assert response.id == query_id
             assert response.error is not None
+            assert response.metadata.get("worker_id") == 0
             err_str = str(response.error)
             assert error_msg in err_str
             assert response.response_output is None

--- a/tests/unit/load_generator/test_async_session.py
+++ b/tests/unit/load_generator/test_async_session.py
@@ -728,13 +728,14 @@ class TestBenchmarkSession:
             QueryResult(
                 id="q-ok",
                 response_output="ok",
-                metadata={"finish_reason": "stop"},
+                metadata={"finish_reason": "stop", "worker_id": 3},
                 completed_at=12345,
             )
         )
         complete = publisher.events_of_type(SampleEventType.COMPLETE)
         assert [(e.conversation_id, e.turn) for e in complete] == [("conv-9", 5)]
         assert complete[0].finish_reason == "stop"
+        assert complete[0].worker_id == 3
         assert "q-ok" not in phase_issuer.uuid_to_conv_info
         assert "q-ok" not in phase_issuer.completed_uuids
 


### PR DESCRIPTION
## What does this PR do?
Adds a worker id field to the logs indicating which worker completed the request. This is useful to debug load imbalance on the server when dealing with multiple front-end servers. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [x] Tests added/updated
- [x] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [x] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
