### PR TITLE
fix : fail on incompatible worker count

### DIFF
--- a/src/inference_endpoint/endpoint_client/config.py
+++ b/src/inference_endpoint/endpoint_client/config.py
@@ -293,6 +293,18 @@ class HTTPClientConfig(WithUpdatesMixin, BaseModel):
         if self.num_workers == -1:
             object.__setattr__(self, "num_workers", _get_auto_num_workers())
 
+        # Workers are pinned round-robin: endpoint_urls[worker_id % len(urls)].
+        # Require an even split so each URL gets the same number of workers.
+        if self.endpoint_urls:
+            n_endpoints = len(self.endpoint_urls)
+            if self.num_workers % n_endpoints != 0:
+                raise ValueError(
+                    f"num_workers ({self.num_workers}) must be a multiple of the "
+                    f"number of endpoint URLs ({n_endpoints}) so each endpoint gets "
+                    f"the same number of workers. Got remainder "
+                    f"{self.num_workers % n_endpoints}."
+                )
+
         if self.adapter is None:
             adapter_path = ADAPTER_MAP.get(self.api_type)
             if not adapter_path:

--- a/tests/unit/endpoint_client/test_http_client_config.py
+++ b/tests/unit/endpoint_client/test_http_client_config.py
@@ -62,7 +62,7 @@ class TestEndpointBudgetScaling:
                     "http://10.0.0.2:8000",
                     "http://10.0.0.3:8000",
                 ],
-                num_workers=10,
+                num_workers=9,  # must be a multiple of len(endpoint_urls)
             )
         assert c.max_connections == 30000  # 10000 ports x 3 distinct endpoints
 
@@ -92,7 +92,7 @@ class TestEndpointBudgetScaling:
                     "http://10.0.0.1:8000/v1/b",
                     "http://10.0.0.1:8000",
                 ],
-                num_workers=10,
+                num_workers=9,  # must be a multiple of len(endpoint_urls)
             )
         assert c.max_connections == 10000  # 1 distinct (host, port)
 
@@ -105,7 +105,7 @@ class TestEndpointBudgetScaling:
                     "http://10.0.0.2:8000",
                     "http://10.0.0.3:8000",
                 ],
-                num_workers=10,
+                num_workers=9,  # must be a multiple of len(endpoint_urls)
                 max_connections=25000,
             )
         assert c.max_connections == 25000
@@ -118,6 +118,30 @@ class TestEndpointBudgetScaling:
                     num_workers=10,
                     max_connections=40000,  # > 2 x 10000
                 )
+
+    def test_num_workers_must_be_multiple_of_endpoint_count(self):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
+            with pytest.raises(ValueError, match="must be a multiple"):
+                cfg.HTTPClientConfig(
+                    endpoint_urls=[
+                        "http://10.0.0.1:8000",
+                        "http://10.0.0.2:8000",
+                        "http://10.0.0.3:8000",
+                    ],
+                    num_workers=10,  # 10 % 3 != 0
+                )
+
+    def test_num_workers_multiple_of_endpoint_count_ok(self):
+        with patch.object(cfg, "get_ephemeral_port_range", return_value=(1, 10000)):
+            c = cfg.HTTPClientConfig(
+                endpoint_urls=[
+                    "http://10.0.0.1:8000",
+                    "http://10.0.0.2:8000",
+                    "http://10.0.0.3:8000",
+                ],
+                num_workers=12,
+            )
+        assert c.num_workers == 12
 
 
 @pytest.mark.unit
@@ -181,7 +205,7 @@ class TestAutoWarmupResolution:
                     "http://10.0.0.2:8000",
                     "http://10.0.0.3:8000",
                 ],
-                num_workers=10,
+                num_workers=9,  # must be a multiple of len(endpoint_urls)
             )
         assert c.warmup_connections == int(30000 * c.auto_warmup_budget_fraction)
 


### PR DESCRIPTION
## What does this PR do?

When the number of workers is not equal to the number of endpoint URLs, there will be load imbalance as some endpoints will get more workers. This is a performance footgun, and should cause the client to fail instead of producing sub-optimal performance numbers requiring performance debugging.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
