### PR TITLE
Add Pyxis runtime for SWE-bench accuracy

### DIFF
--- a/src/inference_endpoint/evaluation/swebench_service/README.md
+++ b/src/inference_endpoint/evaluation/swebench_service/README.md
@@ -1,9 +1,9 @@
 # SWE-bench Service
 
-Runs mini-swe-agent and the SWE-bench harness on a host with Docker. The
+Runs mini-swe-agent and the SWE-bench harness on a host with Docker or Pyxis. The
 benchmark client only needs this service URL, but the service is trusted
 infrastructure: it receives one endpoint URL and optional endpoint credentials, runs
-Docker-backed evaluations, and serves run artifacts.
+container-backed evaluations, and serves run artifacts.
 
 The isolated service subproject commits its own `uv.lock` so deployments use a
 reproducible dependency set.
@@ -17,7 +17,13 @@ uv run --project src/inference_endpoint/evaluation/swebench_service \
 The endpoint URL in the benchmark config must be reachable from the service
 host. Service mode supports exactly one endpoint URL and follows the
 LiveCodeBench-style external-service convention for heavyweight evaluation work.
-Docker is required only on the service host.
+Docker is required only on the service host when using the default runtime. To use
+ARM64 task images from a registry on a retained one-node Slurm allocation, add
+`--runtime pyxis --image-registry REGISTRY`, for example
+`registry.example.com/group/project`. Images must use the name
+`sweb.eval.arm64.<instance_id>:v4.1.0-arm64`.
+Pyxis pulls and caches each image through Enroot; configure registry credentials
+in `~/.config/enroot/.credentials` when the registry requires authentication.
 The benchmark client submits a run to this service only in `ACC` or `BOTH`
 mode; the default `PERF` mode skips external evaluation.
 

--- a/src/inference_endpoint/evaluation/swebench_service/README.md
+++ b/src/inference_endpoint/evaluation/swebench_service/README.md
@@ -24,6 +24,8 @@ ARM64 task images from a registry on a retained one-node Slurm allocation, add
 `sweb.eval.arm64.<instance_id>:v4.1.0-arm64`.
 Pyxis pulls and caches each image through Enroot; configure registry credentials
 in `~/.config/enroot/.credentials` when the registry requires authentication.
+Launch the service on the compute node inside its active one-node Slurm allocation;
+the Pyxis runtime requires both `SLURM_JOB_ID` and `SLURMD_NODENAME`.
 The benchmark client submits a run to this service only in `ACC` or `BOTH`
 mode; the default `PERF` mode skips external evaluation.
 

--- a/src/inference_endpoint/evaluation/swebench_service/README.md
+++ b/src/inference_endpoint/evaluation/swebench_service/README.md
@@ -14,18 +14,62 @@ uv run --project src/inference_endpoint/evaluation/swebench_service \
   --auth-token "$SWEBENCH_SERVICE_AUTH_TOKEN"
 ```
 
-The endpoint URL in the benchmark config must be reachable from the service
-host. Service mode supports exactly one endpoint URL and follows the
-LiveCodeBench-style external-service convention for heavyweight evaluation work.
-Docker is required only on the service host when using the default runtime. To use
-ARM64 task images from a registry on a retained one-node Slurm allocation, add
-`--runtime pyxis --image-registry REGISTRY`, for example
-`registry.example.com/group/project`. Images must use the name
-`sweb.eval.arm64.<instance_id>:v4.1.0-arm64`.
-Pyxis pulls and caches each image through Enroot; configure registry credentials
-in `~/.config/enroot/.credentials` when the registry requires authentication.
-Launch the service on the compute node inside its active one-node Slurm allocation;
-the Pyxis runtime requires both `SLURM_JOB_ID` and `SLURMD_NODENAME`.
+The endpoint URL in the benchmark config must be reachable from the service host.
+Service mode supports exactly one endpoint URL and follows the LiveCodeBench-style
+external-service convention for heavyweight evaluation work.
+
+## Runtime workflow
+
+### Common workflow
+
+The benchmark client sends the selected SWE-bench instances, model configuration,
+and endpoint URL to the service. The service first runs mini-swe-agent to generate
+one patch per instance and writes the patches to `preds.json`. It then evaluates
+those predictions with the SWE-bench harness and returns the aggregate result and
+retained run artifacts. The selected runtime changes where and how the task
+containers execute; it does not change the benchmark client configuration or the
+model endpoint request path.
+
+### Docker runtime
+
+Docker is the default runtime and is required only on the service host. During
+generation, the service runs `mini-extra swebench` unchanged. mini-swe-agent selects
+the official per-instance x86_64 SWE-bench image, starts a writable Docker container
+for the trajectory, and executes every model tool call in that container so its
+filesystem changes persist across turns.
+
+After generation, the service passes `preds.json` to
+`swebench.harness.run_evaluation`. The standard SWE-bench evaluator starts a fresh
+Docker container for each prediction, applies the generated patch, runs the task's
+evaluation script, captures its output, and grades it. The service collects the
+result file produced by the harness and removes containers belonging to the run.
+
+### Pyxis runtime
+
+Select Pyxis with `--runtime pyxis --image-registry REGISTRY`, for example
+`registry.example.com/group/project`. The current path uses ARM64 images named
+`sweb.eval.arm64.<instance_id>:v4.1.0-arm64`. Pyxis pulls and caches them through
+Enroot; configure registry credentials in `~/.config/enroot/.credentials` when the
+registry requires authentication. Launch the service on the compute node inside an
+active one-node Slurm allocation. The runtime requires `SLURM_JOB_ID` and
+`SLURMD_NODENAME` and assumes the node is exclusive to the user.
+
+During generation, the service still uses mini-swe-agent for the agent loop and
+model requests, but replaces its Docker environment with `PyxisEnvironment`. Every
+trajectory receives a named, writable Pyxis container. Each tool call becomes an
+overlapping `srun` step in that container, preserving filesystem changes across
+turns. Tool commands run in private PID namespaces so one trajectory cannot signal
+processes belonging to another trajectory.
+
+After generation, the Pyxis worker evaluates each prediction in a fresh `srun`
+container step because the Docker-based SWE-bench evaluator cannot run on the
+compute node. It mounts the patch, SWE-bench evaluation script, and output file into
+the task image. It preserves SWE-bench 4.1.0's patch-application order, test timeout,
+captured output, and `get_eval_report` grading. A patch failure or test timeout is an
+unresolved task; an `srun`, Enroot, or container-start failure is an infrastructure
+error that fails the run. The service then aggregates the per-instance reports and
+removes its named Pyxis containers.
+
 The benchmark client submits a run to this service only in `ACC` or `BOTH`
 mode; the default `PERF` mode skips external evaluation.
 

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/__main__.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/__main__.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from aiohttp import web
 
 from .config import ServiceConfig
+from .runner import create_runner
 from .server import create_app
 
 
@@ -31,6 +32,8 @@ def main() -> None:
     parser.add_argument("--artifact-root", default="swebench_service_artifacts")
     parser.add_argument("--max-concurrent-runs", type=int, default=1)
     parser.add_argument("--subprocess-timeout-s", type=int, default=24 * 60 * 60)
+    parser.add_argument("--runtime", choices=("docker", "pyxis"), default="docker")
+    parser.add_argument("--image-registry")
     auth_group = parser.add_mutually_exclusive_group()
     auth_group.add_argument("--auth-token")
     auth_group.add_argument("--allow-unauthenticated", action="store_true")
@@ -47,7 +50,13 @@ def main() -> None:
         allow_unauthenticated=args.allow_unauthenticated,
         max_stored_runs=args.max_stored_runs,
     )
-    web.run_app(create_app(config), host=config.host, port=config.port)
+    runner = create_runner(
+        args.runtime,
+        project_root=Path(__file__).resolve().parents[1],
+        subprocess_timeout_s=config.subprocess_timeout_s,
+        image_registry=args.image_registry,
+    )
+    web.run_app(create_app(config, runner=runner), host=config.host, port=config.port)
 
 
 if __name__ == "__main__":

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
@@ -28,6 +28,17 @@ _SAFE_SRUN_ENV = (
     "TMPDIR",
     "XDG_RUNTIME_DIR",
 )
+_STEP_STATUS = "/tmp/.mlperf_srun_status"
+_STEP_SCRIPT = r"""set +e
+status_path=$1
+timeout_s=$2
+shift 2
+printf 'started\n' > "$status_path"
+timeout "$timeout_s" "$@"
+returncode=$?
+printf 'finished:%s\n' "$returncode" > "$status_path"
+exit "$returncode"
+"""
 
 
 def safe_srun_env() -> dict[str, str]:
@@ -45,9 +56,17 @@ def build_srun_command(
     job_id = os.environ.get("SLURM_JOB_ID", "").strip()
     if not job_id:
         raise RunnerError("Pyxis runtime requires SLURM_JOB_ID")
-    command = ["srun", "--overlap", f"--jobid={job_id}", "-N1", "-n1"]
-    if node := os.environ.get("SLURMD_NODENAME", "").strip():
-        command.append(f"--nodelist={node}")
+    node = os.environ.get("SLURMD_NODENAME", "").strip()
+    if not node:
+        raise RunnerError("Pyxis runtime requires SLURMD_NODENAME")
+    command = [
+        "srun",
+        "--overlap",
+        f"--jobid={job_id}",
+        "-N1",
+        "-n1",
+        f"--nodelist={node}",
+    ]
     if image is not None:
         image_ref = str(image.resolve()) if isinstance(image, Path) else image
         command.append(f"--container-image={image_ref}")
@@ -75,6 +94,59 @@ def build_srun_command(
     return command
 
 
+def run_srun_step(
+    *,
+    argv: list[str],
+    status_path: Path,
+    timeout_s: int,
+    failure_path: Path | None = None,
+    image: str | Path | None = None,
+    name: str | None = None,
+    mounts: list[tuple[Path, str]] | None = None,
+    workdir: str | None = None,
+    stderr: int = subprocess.STDOUT,
+) -> subprocess.CompletedProcess[str]:
+    status_path.write_text("pending\n")
+    status_path.chmod(0o666)
+    command = build_srun_command(
+        image=image,
+        name=name,
+        mounts=mounts,
+        workdir=workdir,
+        argv=[
+            "bash",
+            "-c",
+            _STEP_SCRIPT,
+            "pyxis-step",
+            _STEP_STATUS,
+            str(timeout_s),
+            *argv,
+        ],
+    )
+    try:
+        result = subprocess.run(
+            command,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=stderr,
+            timeout=timeout_s + 30,
+            env=safe_srun_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        if failure_path is not None:
+            failure_path.touch()
+        raise RunnerError(
+            "Pyxis infrastructure failure before the command completed"
+        ) from exc
+    if status_path.read_text().strip() != f"finished:{result.returncode}":
+        if failure_path is not None:
+            failure_path.touch()
+        raise RunnerError("Pyxis infrastructure failure before the command completed")
+    return result
+
+
 def resolve_image(image_registry: str, instance_id: str) -> str:
     if Path(instance_id).name != instance_id or instance_id in {".", ".."}:
         raise RunnerError(f"invalid SWE-bench instance ID: {instance_id}")
@@ -84,7 +156,7 @@ def resolve_image(image_registry: str, instance_id: str) -> str:
         if not separator:
             raise RunnerError("Pyxis image registry must include a repository")
         image_registry = f"{host}#{repository}"
-    return f"{image_registry}/sweb.eval.arm64.{instance_id}:v4.1.0-arm64"
+    return f"{image_registry}/sweb.eval.arm64.{instance_id.lower()}:v4.1.0-arm64"
 
 
 class PyxisEnvironmentConfig(BaseModel):
@@ -94,6 +166,7 @@ class PyxisEnvironmentConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
     timeout: int = 30
     interpreter: list[str] = Field(default_factory=lambda: ["bash", "-c"])
+    infrastructure_failure_path: Path | None = None
 
 
 class PyxisEnvironment:
@@ -106,23 +179,18 @@ class PyxisEnvironment:
         self._tmp_dir.chmod(0o1777)
         self._lock = threading.Lock()
         self._cleaned = False
-        command = build_srun_command(
-            image=self.config.image,
-            name=self.name,
-            mounts=[(self._tmp_dir, "/tmp")],
-            workdir=self.config.cwd,
-            argv=["true"],
-        )
         try:
-            subprocess.run(
-                command,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=self.config.timeout,
-                env=safe_srun_env(),
+            run_srun_step(
+                image=self.config.image,
+                name=self.name,
+                mounts=[(self._tmp_dir, "/tmp")],
+                workdir=self.config.cwd,
+                argv=["true"],
+                status_path=self._tmp_dir / Path(_STEP_STATUS).name,
+                timeout_s=self.config.timeout,
+                failure_path=self.config.infrastructure_failure_path,
             )
-        except (OSError, subprocess.SubprocessError) as exc:
+        except RunnerError as exc:
             self.cleanup()
             raise RunnerError(
                 f"failed to start Pyxis container for {self.config.image}"
@@ -135,42 +203,31 @@ class PyxisEnvironment:
         argv = ["env"]
         argv.extend(f"{key}={value}" for key, value in self.config.env.items())
         argv.extend([*self.config.interpreter, command])
-        srun_command = build_srun_command(
-            image=None,
+        result = run_srun_step(
+            argv=argv,
+            status_path=self._tmp_dir / Path(_STEP_STATUS).name,
+            timeout_s=timeout or self.config.timeout,
+            failure_path=self.config.infrastructure_failure_path,
             name=self.name,
             mounts=[(self._tmp_dir, "/tmp")],
             workdir=cwd or self.config.cwd,
-            argv=argv,
         )
         output: dict[str, Any]
-        try:
-            result = subprocess.run(
-                srun_command,
-                text=True,
-                timeout=timeout or self.config.timeout,
-                encoding="utf-8",
-                errors="replace",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                env=safe_srun_env(),
-            )
+        if result.returncode == 124:
+            output = {
+                "output": result.stdout,
+                "returncode": -1,
+                "exception_info": "The command timed out",
+                "extra": {
+                    "exception_type": "TimeoutExpired",
+                    "exception": f"command timed out after {timeout or self.config.timeout}s",
+                },
+            }
+        else:
             output = {
                 "output": result.stdout,
                 "returncode": result.returncode,
                 "exception_info": "",
-            }
-        except Exception as exc:
-            raw_output = getattr(exc, "output", None)
-            if isinstance(raw_output, bytes):
-                raw_output = raw_output.decode("utf-8", errors="replace")
-            output = {
-                "output": raw_output or "",
-                "returncode": -1,
-                "exception_info": f"An error occurred while executing the command: {exc}",
-                "extra": {
-                    "exception_type": type(exc).__name__,
-                    "exception": str(exc),
-                },
             }
         lines = output.get("output", "").lstrip().splitlines(keepends=True)
         if (
@@ -178,6 +235,7 @@ class PyxisEnvironment:
             and lines[0].strip() == "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"
             and output["returncode"] == 0
         ):
+            # mini-swe-agent is installed only in the SWE-bench service subproject.
             from minisweagent.exceptions import Submitted
 
             submission = "".join(lines[1:])
@@ -240,4 +298,7 @@ class PyxisEnvironment:
         try:
             self.cleanup()
         except Exception:
-            pass
+            logging.getLogger(__name__).warning(
+                "Could not clean up Pyxis environment",
+                exc_info=True,
+            )

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
@@ -14,9 +14,11 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 from .runner import RunnerError
+
+logger = logging.getLogger(__name__)
 
 _SAFE_SRUN_ENV = (
     "PATH",
@@ -34,7 +36,7 @@ status_path=$1
 timeout_s=$2
 shift 2
 printf 'started\n' > "$status_path"
-timeout "$timeout_s" "$@"
+unshare --pid --fork --mount-proc timeout "$timeout_s" "$@"
 returncode=$?
 printf 'finished:%s\n' "$returncode" > "$status_path"
 exit "$returncode"
@@ -164,7 +166,11 @@ class PyxisEnvironmentConfig(BaseModel):
     run_id: str
     cwd: str = "/testbed"
     env: dict[str, str] = Field(default_factory=dict)
-    timeout: int = 30
+    timeout_s: int = Field(
+        default=30,
+        validation_alias=AliasChoices("timeout_s", "timeout"),
+        serialization_alias="timeout",
+    )
     interpreter: list[str] = Field(default_factory=lambda: ["bash", "-c"])
     infrastructure_failure_path: Path | None = None
 
@@ -180,6 +186,7 @@ class PyxisEnvironment:
         self._lock = threading.Lock()
         self._cleaned = False
         try:
+            # A no-op initializes and validates the named persistent container.
             run_srun_step(
                 image=self.config.image,
                 name=self.name,
@@ -187,7 +194,7 @@ class PyxisEnvironment:
                 workdir=self.config.cwd,
                 argv=["true"],
                 status_path=self._tmp_dir / Path(_STEP_STATUS).name,
-                timeout_s=self.config.timeout,
+                timeout_s=self.config.timeout_s,
                 failure_path=self.config.infrastructure_failure_path,
             )
         except RunnerError as exc:
@@ -200,13 +207,14 @@ class PyxisEnvironment:
         self, action: dict[str, Any], cwd: str = "", *, timeout: int | None = None
     ) -> dict[str, Any]:
         command = action.get("command", "")
+        logger.debug("Executing Pyxis command: %s", command)
         argv = ["env"]
         argv.extend(f"{key}={value}" for key, value in self.config.env.items())
         argv.extend([*self.config.interpreter, command])
         result = run_srun_step(
             argv=argv,
             status_path=self._tmp_dir / Path(_STEP_STATUS).name,
-            timeout_s=timeout or self.config.timeout,
+            timeout_s=timeout or self.config.timeout_s,
             failure_path=self.config.infrastructure_failure_path,
             name=self.name,
             mounts=[(self._tmp_dir, "/tmp")],
@@ -220,7 +228,9 @@ class PyxisEnvironment:
                 "exception_info": "The command timed out",
                 "extra": {
                     "exception_type": "TimeoutExpired",
-                    "exception": f"command timed out after {timeout or self.config.timeout}s",
+                    "exception": (
+                        f"command timed out after {timeout or self.config.timeout_s}s"
+                    ),
                 },
             }
         else:
@@ -250,7 +260,7 @@ class PyxisEnvironment:
 
     def get_template_vars(self, **kwargs: Any) -> dict[str, Any]:
         return {
-            **self.config.model_dump(),
+            **self.config.model_dump(by_alias=True),
             **platform.uname()._asdict(),
             **kwargs,
         }
@@ -259,7 +269,7 @@ class PyxisEnvironment:
         return {
             "info": {
                 "config": {
-                    "environment": self.config.model_dump(mode="json"),
+                    "environment": self.config.model_dump(mode="json", by_alias=True),
                     "environment_type": (
                         f"{self.__class__.__module__}.{self.__class__.__name__}"
                     ),
@@ -286,7 +296,7 @@ class PyxisEnvironment:
                         env=safe_srun_env(),
                     )
                 except (OSError, RunnerError, subprocess.SubprocessError):
-                    logging.getLogger(__name__).warning(
+                    logger.warning(
                         "Could not remove Pyxis container %s",
                         self.name,
                         exc_info=True,
@@ -298,7 +308,7 @@ class PyxisEnvironment:
         try:
             self.cleanup()
         except Exception:
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "Could not clean up Pyxis environment",
                 exc_info=True,
             )

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
@@ -34,52 +34,43 @@ def safe_srun_env() -> dict[str, str]:
     return {name: os.environ[name] for name in _SAFE_SRUN_ENV if name in os.environ}
 
 
-def _slurm_prefix() -> list[str]:
+def build_srun_command(
+    *,
+    argv: list[str],
+    image: str | Path | None = None,
+    name: str | None = None,
+    mounts: list[tuple[Path, str]] | None = None,
+    workdir: str | None = None,
+) -> list[str]:
     job_id = os.environ.get("SLURM_JOB_ID", "").strip()
     if not job_id:
         raise RunnerError("Pyxis runtime requires SLURM_JOB_ID")
     command = ["srun", "--overlap", f"--jobid={job_id}", "-N1", "-n1"]
     if node := os.environ.get("SLURMD_NODENAME", "").strip():
         command.append(f"--nodelist={node}")
-    return command
-
-
-def build_host_srun_command(argv: list[str]) -> list[str]:
-    return [*_slurm_prefix(), *argv]
-
-
-def build_srun_command(
-    *,
-    image: str | Path | None,
-    name: str | None,
-    mounts: list[tuple[Path, str]],
-    workdir: str,
-    argv: list[str],
-) -> list[str]:
-    if image is None and name is None:
-        raise RunnerError("Pyxis command requires an image or container name")
-    command = _slurm_prefix()
     if image is not None:
         image_ref = str(image.resolve()) if isinstance(image, Path) else image
         command.append(f"--container-image={image_ref}")
     if name is not None:
         command.append(f"--container-name={name}")
-    command.extend(
-        [
-            "--container-writable",
-            "--container-remap-root",
-            "--no-container-mount-home",
-        ]
-    )
-    if mounts:
-        specs = []
-        for source, destination in mounts:
-            source_text = str(source.resolve())
-            if "," in source_text or "," in destination:
-                raise RunnerError("Pyxis mount paths cannot contain commas")
-            specs.append(f"{source_text}:{destination}")
-        command.append("--container-mounts=" + ",".join(specs))
-    command.append(f"--container-workdir={workdir}")
+    if image is not None or name is not None:
+        command.extend(
+            [
+                "--container-writable",
+                "--container-remap-root",
+                "--no-container-mount-home",
+            ]
+        )
+        if mounts:
+            specs = []
+            for source, destination in mounts:
+                source_text = str(source.resolve())
+                if "," in source_text or "," in destination:
+                    raise RunnerError("Pyxis mount paths cannot contain commas")
+                specs.append(f"{source_text}:{destination}")
+            command.append("--container-mounts=" + ",".join(specs))
+        if workdir is not None:
+            command.append(f"--container-workdir={workdir}")
     command.extend(argv)
     return command
 
@@ -115,9 +106,6 @@ class PyxisEnvironment:
         self._tmp_dir.chmod(0o1777)
         self._lock = threading.Lock()
         self._cleaned = False
-        self._start()
-
-    def _start(self) -> None:
         command = build_srun_command(
             image=self.config.image,
             name=self.name,
@@ -154,6 +142,7 @@ class PyxisEnvironment:
             workdir=cwd or self.config.cwd,
             argv=argv,
         )
+        output: dict[str, Any]
         try:
             result = subprocess.run(
                 srun_command,
@@ -183,11 +172,6 @@ class PyxisEnvironment:
                     "exception": str(exc),
                 },
             }
-        self._check_finished(output)
-        return output
-
-    @staticmethod
-    def _check_finished(output: dict[str, Any]) -> None:
         lines = output.get("output", "").lstrip().splitlines(keepends=True)
         if (
             lines
@@ -204,6 +188,7 @@ class PyxisEnvironment:
                     "extra": {"exit_status": "Submitted", "submission": submission},
                 }
             )
+        return output
 
     def get_template_vars(self, **kwargs: Any) -> dict[str, Any]:
         return {
@@ -233,13 +218,9 @@ class PyxisEnvironment:
             if os.environ.get("SLURM_JOB_ID", "").strip():
                 try:
                     subprocess.run(
-                        [
-                            *_slurm_prefix(),
-                            "enroot",
-                            "remove",
-                            "-f",
-                            f"pyxis_{self.name}",
-                        ],
+                        build_srun_command(
+                            argv=["enroot", "remove", "-f", f"pyxis_{self.name}"]
+                        ),
                         check=False,
                         capture_output=True,
                         text=True,

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import re
+import subprocess
+import tempfile
+import threading
+import uuid
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .runner import RunnerError
+
+_SAFE_SRUN_ENV = (
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "TMPDIR",
+    "XDG_RUNTIME_DIR",
+)
+
+
+def safe_srun_env() -> dict[str, str]:
+    return {name: os.environ[name] for name in _SAFE_SRUN_ENV if name in os.environ}
+
+
+def _slurm_prefix() -> list[str]:
+    job_id = os.environ.get("SLURM_JOB_ID", "").strip()
+    if not job_id:
+        raise RunnerError("Pyxis runtime requires SLURM_JOB_ID")
+    command = ["srun", "--overlap", f"--jobid={job_id}", "-N1", "-n1"]
+    if node := os.environ.get("SLURMD_NODENAME", "").strip():
+        command.append(f"--nodelist={node}")
+    return command
+
+
+def build_host_srun_command(argv: list[str]) -> list[str]:
+    return [*_slurm_prefix(), *argv]
+
+
+def build_srun_command(
+    *,
+    image: str | Path | None,
+    name: str | None,
+    mounts: list[tuple[Path, str]],
+    workdir: str,
+    argv: list[str],
+) -> list[str]:
+    if image is None and name is None:
+        raise RunnerError("Pyxis command requires an image or container name")
+    command = _slurm_prefix()
+    if image is not None:
+        image_ref = str(image.resolve()) if isinstance(image, Path) else image
+        command.append(f"--container-image={image_ref}")
+    if name is not None:
+        command.append(f"--container-name={name}")
+    command.extend(
+        [
+            "--container-writable",
+            "--container-remap-root",
+            "--no-container-mount-home",
+        ]
+    )
+    if mounts:
+        specs = []
+        for source, destination in mounts:
+            source_text = str(source.resolve())
+            if "," in source_text or "," in destination:
+                raise RunnerError("Pyxis mount paths cannot contain commas")
+            specs.append(f"{source_text}:{destination}")
+        command.append("--container-mounts=" + ",".join(specs))
+    command.append(f"--container-workdir={workdir}")
+    command.extend(argv)
+    return command
+
+
+def resolve_image(image_registry: str, instance_id: str) -> str:
+    if Path(instance_id).name != instance_id or instance_id in {".", ".."}:
+        raise RunnerError(f"invalid SWE-bench instance ID: {instance_id}")
+    image_registry = image_registry.rstrip("/")
+    if "#" not in image_registry:
+        host, separator, repository = image_registry.partition("/")
+        if not separator:
+            raise RunnerError("Pyxis image registry must include a repository")
+        image_registry = f"{host}#{repository}"
+    return f"{image_registry}/sweb.eval.arm64.{instance_id}:v4.1.0-arm64"
+
+
+class PyxisEnvironmentConfig(BaseModel):
+    image: str | Path
+    run_id: str
+    cwd: str = "/testbed"
+    env: dict[str, str] = Field(default_factory=dict)
+    timeout: int = 30
+    interpreter: list[str] = Field(default_factory=lambda: ["bash", "-c"])
+
+
+class PyxisEnvironment:
+    def __init__(self, **kwargs: Any):
+        self.config = PyxisEnvironmentConfig(**kwargs)
+        safe_run_id = re.sub(r"[^A-Za-z0-9_.-]", "-", self.config.run_id)[:24]
+        self.name = f"mswe_{safe_run_id}_{uuid.uuid4().hex[:8]}"
+        self._tmp = tempfile.TemporaryDirectory(prefix=f"pyxis_{self.name}_")
+        self._tmp_dir = Path(self._tmp.name)
+        self._tmp_dir.chmod(0o1777)
+        self._lock = threading.Lock()
+        self._cleaned = False
+        self._start()
+
+    def _start(self) -> None:
+        command = build_srun_command(
+            image=self.config.image,
+            name=self.name,
+            mounts=[(self._tmp_dir, "/tmp")],
+            workdir=self.config.cwd,
+            argv=["true"],
+        )
+        try:
+            subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=self.config.timeout,
+                env=safe_srun_env(),
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            self.cleanup()
+            raise RunnerError(
+                f"failed to start Pyxis container for {self.config.image}"
+            ) from exc
+
+    def execute(
+        self, action: dict[str, Any], cwd: str = "", *, timeout: int | None = None
+    ) -> dict[str, Any]:
+        command = action.get("command", "")
+        argv = ["env"]
+        argv.extend(f"{key}={value}" for key, value in self.config.env.items())
+        argv.extend([*self.config.interpreter, command])
+        srun_command = build_srun_command(
+            image=None,
+            name=self.name,
+            mounts=[(self._tmp_dir, "/tmp")],
+            workdir=cwd or self.config.cwd,
+            argv=argv,
+        )
+        try:
+            result = subprocess.run(
+                srun_command,
+                text=True,
+                timeout=timeout or self.config.timeout,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=safe_srun_env(),
+            )
+            output = {
+                "output": result.stdout,
+                "returncode": result.returncode,
+                "exception_info": "",
+            }
+        except Exception as exc:
+            raw_output = getattr(exc, "output", None)
+            if isinstance(raw_output, bytes):
+                raw_output = raw_output.decode("utf-8", errors="replace")
+            output = {
+                "output": raw_output or "",
+                "returncode": -1,
+                "exception_info": f"An error occurred while executing the command: {exc}",
+                "extra": {
+                    "exception_type": type(exc).__name__,
+                    "exception": str(exc),
+                },
+            }
+        self._check_finished(output)
+        return output
+
+    @staticmethod
+    def _check_finished(output: dict[str, Any]) -> None:
+        lines = output.get("output", "").lstrip().splitlines(keepends=True)
+        if (
+            lines
+            and lines[0].strip() == "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"
+            and output["returncode"] == 0
+        ):
+            from minisweagent.exceptions import Submitted
+
+            submission = "".join(lines[1:])
+            raise Submitted(
+                {
+                    "role": "exit",
+                    "content": submission,
+                    "extra": {"exit_status": "Submitted", "submission": submission},
+                }
+            )
+
+    def get_template_vars(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            **self.config.model_dump(),
+            **platform.uname()._asdict(),
+            **kwargs,
+        }
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "info": {
+                "config": {
+                    "environment": self.config.model_dump(mode="json"),
+                    "environment_type": (
+                        f"{self.__class__.__module__}.{self.__class__.__name__}"
+                    ),
+                }
+            }
+        }
+
+    def cleanup(self) -> None:
+        with self._lock:
+            if self._cleaned:
+                return
+            self._cleaned = True
+        try:
+            if os.environ.get("SLURM_JOB_ID", "").strip():
+                try:
+                    subprocess.run(
+                        [
+                            *_slurm_prefix(),
+                            "enroot",
+                            "remove",
+                            "-f",
+                            f"pyxis_{self.name}",
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        env=safe_srun_env(),
+                    )
+                except (OSError, RunnerError, subprocess.SubprocessError):
+                    logging.getLogger(__name__).warning(
+                        "Could not remove Pyxis container %s",
+                        self.name,
+                        exc_info=True,
+                    )
+        finally:
+            self._tmp.cleanup()
+
+    def __del__(self) -> None:
+        try:
+            self.cleanup()
+        except Exception:
+            pass

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import contextlib
+import copy
+import json
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+from .artifacts import atomic_write_bytes
+from .pyxis_environment import build_srun_command, resolve_image, safe_srun_env
+
+_PRINT_LOCK = threading.Lock()
+_EVAL_SCRIPT = r"""set -eu
+
+patch_path=$1
+eval_path=$2
+output_path=$3
+timeout_s=$4
+
+cd /testbed
+if git apply --verbose "$patch_path" || \
+    git apply --verbose --reject "$patch_path" || \
+    patch --batch --fuzz=5 -p1 -i "$patch_path"; then
+    echo ">>>>> Applied Patch"
+else
+    echo ">>>>> Patch Apply Failed"
+    exit 1
+fi
+
+set +e
+timeout "$timeout_s" /bin/bash "$eval_path" >"$output_path" 2>&1
+status=$?
+set -e
+cat "$output_path"
+if [[ $status -eq 124 ]]; then
+    echo "Timeout error: $timeout_s seconds exceeded." >>"$output_path"
+    exit 124
+fi
+exit 0
+"""
+
+
+def _evaluate_instance(
+    *,
+    test_spec: Any,
+    prediction: dict[str, Any],
+    image: str | Path,
+    output_dir: Path,
+    run_id: str,
+    timeout_s: int,
+) -> None:
+    instance_id = test_spec.instance_id
+    safe_model = prediction["model_name_or_path"].replace("/", "__")
+    log_dir = output_dir / "logs" / "run_evaluation" / run_id / safe_model / instance_id
+    log_dir.mkdir(parents=True, exist_ok=True)
+    patch_path = log_dir / "patch.diff"
+    eval_path = log_dir / "eval.sh"
+    output_path = log_dir / "test_output.txt"
+    report_path = log_dir / "report.json"
+    patch_path.write_text(prediction["model_patch"])
+    eval_path.write_text(test_spec.eval_script)
+    output_path.write_text("")
+    report_path.unlink(missing_ok=True)
+
+    command = build_srun_command(
+        image=image,
+        name=None,
+        mounts=[
+            (patch_path, "/tmp/swebench_patch.diff"),
+            (eval_path, "/tmp/swebench_eval.sh"),
+            (output_path, "/tmp/swebench_test_output.txt"),
+        ],
+        workdir="/testbed",
+        argv=[
+            "bash",
+            "-c",
+            _EVAL_SCRIPT,
+            "pyxis-eval",
+            "/tmp/swebench_patch.diff",
+            "/tmp/swebench_eval.sh",
+            "/tmp/swebench_test_output.txt",
+            str(timeout_s),
+        ],
+    )
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s + 60,
+        env=safe_srun_env(),
+    )
+    with _PRINT_LOCK:
+        print(f"[{instance_id}]\n{result.stdout}{result.stderr}", flush=True)
+    if result.returncode != 0:
+        return
+
+    from swebench.harness.grading import get_eval_report
+
+    report = get_eval_report(
+        test_spec=test_spec,
+        prediction=prediction,
+        test_log_path=output_path,
+        include_tests_status=True,
+    )
+    atomic_write_bytes(report_path, (json.dumps(report, indent=4) + "\n").encode())
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    agent_parser = commands.add_parser("agent")
+    agent_parser.add_argument("--model", required=True)
+    agent_parser.add_argument("--config", type=Path, required=True)
+    agent_parser.add_argument("--subset", required=True)
+    agent_parser.add_argument("--split", required=True)
+    agent_parser.add_argument("--filter", required=True)
+    agent_parser.add_argument("--workers", type=int, required=True)
+    agent_parser.add_argument("--output", type=Path, required=True)
+    agent_parser.add_argument("--image-registry", required=True)
+
+    eval_parser = commands.add_parser("eval")
+    eval_parser.add_argument("--dataset-name", required=True)
+    eval_parser.add_argument("--split", required=True)
+    eval_parser.add_argument("--predictions-path", type=Path, required=True)
+    eval_parser.add_argument("--max-workers", type=int, required=True)
+    eval_parser.add_argument("--run-id", required=True)
+    eval_parser.add_argument("--image-registry", required=True)
+    eval_parser.add_argument("--output-dir", type=Path, required=True)
+    eval_parser.add_argument("--timeout", type=int, default=1800)
+    eval_parser.add_argument("--instance-ids", nargs="+", required=True)
+    args = parser.parse_args(argv)
+
+    if args.command == "agent":
+        from minisweagent.environments import get_environment
+        from minisweagent.run.benchmarks import swebench
+
+        def get_pyxis_environment(config: dict, instance: dict):
+            environment_config = copy.deepcopy(config.get("environment", {}))
+            environment_config["image"] = resolve_image(
+                args.image_registry, instance["instance_id"]
+            )
+            return get_environment(environment_config)
+
+        base_agent = swebench.ProgressTrackingAgent
+
+        class LiveTrajectoryAgent(base_agent):  # type: ignore[misc, valid-type]
+            def __init__(self, *agent_args: Any, instance_id: str = "", **kwargs: Any):
+                kwargs["output_path"] = (
+                    args.output / instance_id / f"{instance_id}.live.json"
+                )
+                super().__init__(*agent_args, instance_id=instance_id, **kwargs)
+
+        swebench.get_sb_environment = get_pyxis_environment
+        swebench.ProgressTrackingAgent = LiveTrajectoryAgent
+        swebench.main(
+            subset=args.subset,
+            split=args.split,
+            slice_spec="",
+            filter_spec=args.filter,
+            shuffle=False,
+            output=str(args.output),
+            workers=args.workers,
+            model=args.model,
+            model_class=None,
+            redo_existing=False,
+            config_spec=[str(args.config)],
+            environment_class=("swebench_service.pyxis_environment.PyxisEnvironment"),
+        )
+        return
+
+    from swebench.harness.reporting import make_run_report
+    from swebench.harness.test_spec.test_spec import make_test_spec
+    from swebench.harness.utils import (
+        get_predictions_from_file,
+        load_swebench_dataset,
+    )
+
+    predictions = {
+        prediction["instance_id"]: prediction
+        for prediction in get_predictions_from_file(
+            str(args.predictions_path), args.dataset_name, args.split
+        )
+        if prediction["instance_id"] in args.instance_ids
+    }
+    rows = load_swebench_dataset(args.dataset_name, args.split, args.instance_ids)
+    images = {
+        instance_id: resolve_image(args.image_registry, instance_id)
+        for instance_id in args.instance_ids
+    }
+    payloads = []
+    for row in rows:
+        instance_id = row["instance_id"]
+        prediction = predictions.get(instance_id)
+        if prediction is None or prediction.get("model_patch") in {"", None}:
+            continue
+        payloads.append(
+            {
+                "test_spec": make_test_spec(row, arch="arm64"),
+                "prediction": prediction,
+                "image": images[instance_id],
+                "output_dir": args.output_dir,
+                "run_id": args.run_id,
+                "timeout_s": args.timeout,
+            }
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=args.max_workers
+    ) as executor:
+        futures = [
+            executor.submit(_evaluate_instance, **payload) for payload in payloads
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                future.result()
+            except Exception as exc:
+                with _PRINT_LOCK:
+                    print(f"Pyxis evaluation failed: {exc}", flush=True)
+
+    output_dir = args.output_dir.resolve()
+    with contextlib.chdir(output_dir):
+        make_run_report(
+            predictions,
+            [{"instance_id": instance_id} for instance_id in args.instance_ids],
+            args.run_id,
+            client=None,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
@@ -14,9 +14,11 @@ from pathlib import Path
 from typing import Any
 
 from .artifacts import atomic_write_bytes
-from .pyxis_environment import build_srun_command, resolve_image, safe_srun_env
+from .pyxis_environment import resolve_image, run_srun_step
+from .runner import RunnerError
 
 _PRINT_LOCK = threading.Lock()
+_INFRASTRUCTURE_FAILURE = ".pyxis_infrastructure_failure"
 _EVAL_SCRIPT = r"""set -eu
 
 patch_path=$1
@@ -48,41 +50,46 @@ exit 0
 
 
 def _run_agent(args: argparse.Namespace) -> None:
+    # Generation-only dependencies are loaded only in the agent worker mode.
     from minisweagent.environments import get_environment
     from minisweagent.run.benchmarks import swebench
+
+    failure_path = args.output / _INFRASTRUCTURE_FAILURE
+    failure_path.unlink(missing_ok=True)
 
     def get_pyxis_environment(config: dict, instance: dict):
         environment_config = copy.deepcopy(config.get("environment", {}))
         environment_config["image"] = resolve_image(
             args.image_registry, instance["instance_id"]
         )
+        environment_config["infrastructure_failure_path"] = str(failure_path)
         return get_environment(environment_config)
 
-    base_agent = swebench.ProgressTrackingAgent
-
-    class LiveTrajectoryAgent(base_agent):  # type: ignore[misc, valid-type]
-        def __init__(self, *agent_args: Any, instance_id: str = "", **kwargs: Any):
-            kwargs["output_path"] = (
-                args.output / instance_id / f"{instance_id}.live.json"
-            )
-            super().__init__(*agent_args, instance_id=instance_id, **kwargs)
-
-    swebench.get_sb_environment = get_pyxis_environment
-    swebench.ProgressTrackingAgent = LiveTrajectoryAgent
-    swebench.main(
-        subset=args.subset,
-        split=args.split,
-        slice_spec="",
-        filter_spec=args.filter,
-        shuffle=False,
-        output=str(args.output),
-        workers=args.workers,
-        model=args.model,
-        model_class=None,
-        redo_existing=False,
-        config_spec=[str(args.config)],
-        environment_class="swebench_service.pyxis_environment.PyxisEnvironment",
-    )
+    if not hasattr(swebench, "get_sb_environment"):
+        raise RuntimeError(
+            "installed mini-swe-agent does not expose get_sb_environment"
+        )
+    original_get_sb_environment = swebench.get_sb_environment
+    try:
+        swebench.get_sb_environment = get_pyxis_environment
+        swebench.main(
+            subset=args.subset,
+            split=args.split,
+            slice_spec="",
+            filter_spec=args.filter,
+            shuffle=False,
+            output=str(args.output),
+            workers=args.workers,
+            model=args.model,
+            model_class=None,
+            redo_existing=False,
+            config_spec=[str(args.config)],
+            environment_class="swebench_service.pyxis_environment.PyxisEnvironment",
+        )
+        if failure_path.exists():
+            raise RunnerError("Pyxis infrastructure failure during agent execution")
+    finally:
+        swebench.get_sb_environment = original_get_sb_environment
 
 
 def _evaluate_instance(
@@ -107,14 +114,20 @@ def _evaluate_instance(
     output_path.write_text("")
     report_path.unlink(missing_ok=True)
 
-    command = build_srun_command(
+    mounts = [
+        (patch_path, "/tmp/swebench_patch.diff"),
+        (eval_path, "/tmp/swebench_eval.sh"),
+        (output_path, "/tmp/swebench_test_output.txt"),
+    ]
+    status_path = log_dir / ".mlperf_srun_status"
+    mounts.append((status_path, "/tmp/.mlperf_srun_status"))
+    result = run_srun_step(
         image=image,
-        mounts=[
-            (patch_path, "/tmp/swebench_patch.diff"),
-            (eval_path, "/tmp/swebench_eval.sh"),
-            (output_path, "/tmp/swebench_test_output.txt"),
-        ],
+        mounts=mounts,
         workdir="/testbed",
+        status_path=status_path,
+        timeout_s=timeout_s + 30,
+        stderr=subprocess.PIPE,
         argv=[
             "bash",
             "-c",
@@ -126,18 +139,17 @@ def _evaluate_instance(
             str(timeout_s),
         ],
     )
-    result = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        timeout=timeout_s + 60,
-        env=safe_srun_env(),
-    )
     with _PRINT_LOCK:
         print(f"[{instance_id}]\n{result.stdout}{result.stderr}", flush=True)
-    if result.returncode != 0:
+    if result.returncode in {1, 124}:
         return
+    if result.returncode != 0:
+        raise RunnerError(
+            f"unexpected Pyxis evaluation exit code for {instance_id}: "
+            f"{result.returncode}"
+        )
 
+    # Grading is an evaluation-only dependency and is not needed in agent mode.
     from swebench.harness.grading import get_eval_report
 
     report = get_eval_report(
@@ -150,6 +162,7 @@ def _evaluate_instance(
 
 
 def _run_eval(args: argparse.Namespace) -> None:
+    # Evaluation-only SWE-bench harness dependencies are not needed in agent mode.
     from swebench.harness.reporting import make_run_report
     from swebench.harness.test_spec.test_spec import make_test_spec
     from swebench.harness.utils import (
@@ -189,15 +202,25 @@ def _run_eval(args: argparse.Namespace) -> None:
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=args.max_workers
     ) as executor:
-        futures = [
-            executor.submit(_evaluate_instance, **payload) for payload in payloads
-        ]
+        futures = {
+            executor.submit(_evaluate_instance, **payload): payload[
+                "test_spec"
+            ].instance_id
+            for payload in payloads
+        }
+        failures = []
         for future in concurrent.futures.as_completed(futures):
             try:
                 future.result()
             except Exception as exc:
                 with _PRINT_LOCK:
                     print(f"Pyxis evaluation failed: {exc}", flush=True)
+                failures.append(futures[future])
+        if failures:
+            raise RunnerError(
+                "Pyxis infrastructure failure evaluating: "
+                + ", ".join(sorted(failures))
+            )
 
     output_dir = args.output_dir.resolve()
     with contextlib.chdir(output_dir):

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
@@ -19,6 +19,10 @@ from .runner import RunnerError
 
 _PRINT_LOCK = threading.Lock()
 _INFRASTRUCTURE_FAILURE = ".pyxis_infrastructure_failure"
+# This mirrors the per-instance portion of SWE-bench 4.1.0's Docker evaluator:
+# apply the patch with the same three fallbacks, run eval.sh with its timeout, and
+# preserve the test output for get_eval_report(). Pyxis mounts these files and
+# executes them with srun instead of copying them through the Docker API.
 _EVAL_SCRIPT = r"""set -eu
 
 patch_path=$1

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_worker.py
@@ -47,6 +47,44 @@ exit 0
 """
 
 
+def _run_agent(args: argparse.Namespace) -> None:
+    from minisweagent.environments import get_environment
+    from minisweagent.run.benchmarks import swebench
+
+    def get_pyxis_environment(config: dict, instance: dict):
+        environment_config = copy.deepcopy(config.get("environment", {}))
+        environment_config["image"] = resolve_image(
+            args.image_registry, instance["instance_id"]
+        )
+        return get_environment(environment_config)
+
+    base_agent = swebench.ProgressTrackingAgent
+
+    class LiveTrajectoryAgent(base_agent):  # type: ignore[misc, valid-type]
+        def __init__(self, *agent_args: Any, instance_id: str = "", **kwargs: Any):
+            kwargs["output_path"] = (
+                args.output / instance_id / f"{instance_id}.live.json"
+            )
+            super().__init__(*agent_args, instance_id=instance_id, **kwargs)
+
+    swebench.get_sb_environment = get_pyxis_environment
+    swebench.ProgressTrackingAgent = LiveTrajectoryAgent
+    swebench.main(
+        subset=args.subset,
+        split=args.split,
+        slice_spec="",
+        filter_spec=args.filter,
+        shuffle=False,
+        output=str(args.output),
+        workers=args.workers,
+        model=args.model,
+        model_class=None,
+        redo_existing=False,
+        config_spec=[str(args.config)],
+        environment_class="swebench_service.pyxis_environment.PyxisEnvironment",
+    )
+
+
 def _evaluate_instance(
     *,
     test_spec: Any,
@@ -71,7 +109,6 @@ def _evaluate_instance(
 
     command = build_srun_command(
         image=image,
-        name=None,
         mounts=[
             (patch_path, "/tmp/swebench_patch.diff"),
             (eval_path, "/tmp/swebench_eval.sh"),
@@ -112,70 +149,7 @@ def _evaluate_instance(
     atomic_write_bytes(report_path, (json.dumps(report, indent=4) + "\n").encode())
 
 
-def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser()
-    commands = parser.add_subparsers(dest="command", required=True)
-
-    agent_parser = commands.add_parser("agent")
-    agent_parser.add_argument("--model", required=True)
-    agent_parser.add_argument("--config", type=Path, required=True)
-    agent_parser.add_argument("--subset", required=True)
-    agent_parser.add_argument("--split", required=True)
-    agent_parser.add_argument("--filter", required=True)
-    agent_parser.add_argument("--workers", type=int, required=True)
-    agent_parser.add_argument("--output", type=Path, required=True)
-    agent_parser.add_argument("--image-registry", required=True)
-
-    eval_parser = commands.add_parser("eval")
-    eval_parser.add_argument("--dataset-name", required=True)
-    eval_parser.add_argument("--split", required=True)
-    eval_parser.add_argument("--predictions-path", type=Path, required=True)
-    eval_parser.add_argument("--max-workers", type=int, required=True)
-    eval_parser.add_argument("--run-id", required=True)
-    eval_parser.add_argument("--image-registry", required=True)
-    eval_parser.add_argument("--output-dir", type=Path, required=True)
-    eval_parser.add_argument("--timeout", type=int, default=1800)
-    eval_parser.add_argument("--instance-ids", nargs="+", required=True)
-    args = parser.parse_args(argv)
-
-    if args.command == "agent":
-        from minisweagent.environments import get_environment
-        from minisweagent.run.benchmarks import swebench
-
-        def get_pyxis_environment(config: dict, instance: dict):
-            environment_config = copy.deepcopy(config.get("environment", {}))
-            environment_config["image"] = resolve_image(
-                args.image_registry, instance["instance_id"]
-            )
-            return get_environment(environment_config)
-
-        base_agent = swebench.ProgressTrackingAgent
-
-        class LiveTrajectoryAgent(base_agent):  # type: ignore[misc, valid-type]
-            def __init__(self, *agent_args: Any, instance_id: str = "", **kwargs: Any):
-                kwargs["output_path"] = (
-                    args.output / instance_id / f"{instance_id}.live.json"
-                )
-                super().__init__(*agent_args, instance_id=instance_id, **kwargs)
-
-        swebench.get_sb_environment = get_pyxis_environment
-        swebench.ProgressTrackingAgent = LiveTrajectoryAgent
-        swebench.main(
-            subset=args.subset,
-            split=args.split,
-            slice_spec="",
-            filter_spec=args.filter,
-            shuffle=False,
-            output=str(args.output),
-            workers=args.workers,
-            model=args.model,
-            model_class=None,
-            redo_existing=False,
-            config_spec=[str(args.config)],
-            environment_class=("swebench_service.pyxis_environment.PyxisEnvironment"),
-        )
-        return
-
+def _run_eval(args: argparse.Namespace) -> None:
     from swebench.harness.reporting import make_run_report
     from swebench.harness.test_spec.test_spec import make_test_spec
     from swebench.harness.utils import (
@@ -233,6 +207,38 @@ def main(argv: list[str] | None = None) -> None:
             args.run_id,
             client=None,
         )
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    agent_parser = commands.add_parser("agent")
+    agent_parser.add_argument("--model", required=True)
+    agent_parser.add_argument("--config", type=Path, required=True)
+    agent_parser.add_argument("--subset", required=True)
+    agent_parser.add_argument("--split", required=True)
+    agent_parser.add_argument("--filter", required=True)
+    agent_parser.add_argument("--workers", type=int, required=True)
+    agent_parser.add_argument("--output", type=Path, required=True)
+    agent_parser.add_argument("--image-registry", required=True)
+
+    eval_parser = commands.add_parser("eval")
+    eval_parser.add_argument("--dataset-name", required=True)
+    eval_parser.add_argument("--split", required=True)
+    eval_parser.add_argument("--predictions-path", type=Path, required=True)
+    eval_parser.add_argument("--max-workers", type=int, required=True)
+    eval_parser.add_argument("--run-id", required=True)
+    eval_parser.add_argument("--image-registry", required=True)
+    eval_parser.add_argument("--output-dir", type=Path, required=True)
+    eval_parser.add_argument("--timeout", type=int, default=1800)
+    eval_parser.add_argument("--instance-ids", nargs="+", required=True)
+    args = parser.parse_args(argv)
+
+    if args.command == "agent":
+        _run_agent(args)
+    else:
+        _run_eval(args)
 
 
 if __name__ == "__main__":

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
@@ -15,11 +15,6 @@
 
 from __future__ import annotations
 
-import argparse
-import concurrent.futures
-import contextlib
-import copy
-import json
 import logging
 import os
 import re
@@ -90,35 +85,6 @@ _LOG_TAIL_MAX_BYTES = 64 * 1024
 _LOG_TAIL_MAX_LINES = 50
 _RUN_LABEL = "com.mlcommons.endpoints.swebench-run"
 _PROCESS_TERMINATE_TIMEOUT_S = 10
-_PYXIS_PRINT_LOCK = threading.Lock()
-_PYXIS_EVAL_SCRIPT = r"""set -eu
-
-patch_path=$1
-eval_path=$2
-output_path=$3
-timeout_s=$4
-
-cd /testbed
-if git apply --verbose "$patch_path" || \
-    git apply --verbose --reject "$patch_path" || \
-    patch --batch --fuzz=5 -p1 -i "$patch_path"; then
-    echo ">>>>> Applied Patch"
-else
-    echo ">>>>> Patch Apply Failed"
-    exit 1
-fi
-
-set +e
-timeout "$timeout_s" /bin/bash "$eval_path" >"$output_path" 2>&1
-status=$?
-set -e
-cat "$output_path"
-if [[ $status -eq 124 ]]; then
-    echo "Timeout error: $timeout_s seconds exceeded." >>"$output_path"
-    exit 124
-fi
-exit 0
-"""
 
 
 def _normalize_endpoint_base(endpoint: str) -> str:
@@ -699,8 +665,8 @@ class PyxisSweBenchRunner(SweBenchRunner):
         command = [
             sys.executable,
             "-m",
-            "swebench_service.runner",
-            "pyxis-agent",
+            "swebench_service.pyxis_worker",
+            "agent",
             "--model",
             request.model_name,
             "--config",
@@ -748,8 +714,8 @@ class PyxisSweBenchRunner(SweBenchRunner):
         command = [
             sys.executable,
             "-m",
-            "swebench_service.runner",
-            "pyxis-eval",
+            "swebench_service.pyxis_worker",
+            "eval",
             "--dataset-name",
             dataset_name,
             "--split",
@@ -824,219 +790,6 @@ class PyxisSweBenchRunner(SweBenchRunner):
             ) from exc
 
 
-def _enable_live_trajectory_saves(swebench: Any, output_dir: Path) -> None:
-    base_agent = swebench.ProgressTrackingAgent
-
-    class LiveTrajectoryAgent(base_agent):  # type: ignore[misc, valid-type]
-        def __init__(self, *args: Any, instance_id: str = "", **kwargs: Any):
-            kwargs["output_path"] = (
-                output_dir / instance_id / f"{instance_id}.live.json"
-            )
-            super().__init__(*args, instance_id=instance_id, **kwargs)
-
-    swebench.ProgressTrackingAgent = LiveTrajectoryAgent
-
-
-def _pyxis_agent_main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--model", required=True)
-    parser.add_argument("--config", type=Path, required=True)
-    parser.add_argument("--subset", required=True)
-    parser.add_argument("--split", required=True)
-    parser.add_argument("--filter", required=True)
-    parser.add_argument("--workers", type=int, required=True)
-    parser.add_argument("--output", type=Path, required=True)
-    parser.add_argument("--image-registry", required=True)
-    args = parser.parse_args(argv)
-
-    from minisweagent.environments import get_environment
-    from minisweagent.run.benchmarks import swebench
-
-    from .pyxis_environment import resolve_image
-
-    def get_pyxis_environment(config: dict, instance: dict):
-        environment_config = copy.deepcopy(config.get("environment", {}))
-        environment_config["image"] = resolve_image(
-            args.image_registry, instance["instance_id"]
-        )
-        return get_environment(environment_config)
-
-    swebench.get_sb_environment = get_pyxis_environment
-    _enable_live_trajectory_saves(swebench, args.output)
-    swebench.main(
-        subset=args.subset,
-        split=args.split,
-        slice_spec="",
-        filter_spec=args.filter,
-        shuffle=False,
-        output=str(args.output),
-        workers=args.workers,
-        model=args.model,
-        model_class=None,
-        redo_existing=False,
-        config_spec=[str(args.config)],
-        environment_class=("swebench_service.pyxis_environment.PyxisEnvironment"),
-    )
-
-
-def _write_pyxis_run_report(
-    *,
-    output_dir: Path,
-    run_id: str,
-    instance_ids: list[str],
-    predictions: dict[str, dict[str, Any]],
-) -> Path:
-    from swebench.harness.reporting import make_run_report
-
-    output_dir = output_dir.resolve()
-    with contextlib.chdir(output_dir):
-        result_path = make_run_report(
-            predictions,
-            [{"instance_id": instance_id} for instance_id in instance_ids],
-            run_id,
-            client=None,
-        )
-    return output_dir / result_path
-
-
-def _evaluate_pyxis_instance(
-    *,
-    test_spec: Any,
-    prediction: dict[str, Any],
-    image: str | Path,
-    output_dir: Path,
-    run_id: str,
-    timeout_s: int,
-) -> None:
-    from .pyxis_environment import build_srun_command, safe_srun_env
-
-    instance_id = test_spec.instance_id
-    safe_model = prediction["model_name_or_path"].replace("/", "__")
-    log_dir = output_dir / "logs" / "run_evaluation" / run_id / safe_model / instance_id
-    log_dir.mkdir(parents=True, exist_ok=True)
-    patch_path = log_dir / "patch.diff"
-    eval_path = log_dir / "eval.sh"
-    output_path = log_dir / "test_output.txt"
-    report_path = log_dir / "report.json"
-    patch_path.write_text(prediction["model_patch"])
-    eval_path.write_text(test_spec.eval_script)
-    output_path.write_text("")
-    report_path.unlink(missing_ok=True)
-
-    command = build_srun_command(
-        image=image,
-        name=None,
-        mounts=[
-            (patch_path, "/tmp/swebench_patch.diff"),
-            (eval_path, "/tmp/swebench_eval.sh"),
-            (output_path, "/tmp/swebench_test_output.txt"),
-        ],
-        workdir="/testbed",
-        argv=[
-            "bash",
-            "-c",
-            _PYXIS_EVAL_SCRIPT,
-            "pyxis-eval",
-            "/tmp/swebench_patch.diff",
-            "/tmp/swebench_eval.sh",
-            "/tmp/swebench_test_output.txt",
-            str(timeout_s),
-        ],
-    )
-    result = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        timeout=timeout_s + 60,
-        env=safe_srun_env(),
-    )
-    with _PYXIS_PRINT_LOCK:
-        print(f"[{instance_id}]\n{result.stdout}{result.stderr}", flush=True)
-    if result.returncode != 0:
-        return
-
-    from swebench.harness.grading import get_eval_report
-
-    report = get_eval_report(
-        test_spec=test_spec,
-        prediction=prediction,
-        test_log_path=output_path,
-        include_tests_status=True,
-    )
-    atomic_write_bytes(report_path, (json.dumps(report, indent=4) + "\n").encode())
-
-
-def _pyxis_eval_main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--dataset-name", required=True)
-    parser.add_argument("--split", required=True)
-    parser.add_argument("--predictions-path", type=Path, required=True)
-    parser.add_argument("--max-workers", type=int, required=True)
-    parser.add_argument("--run-id", required=True)
-    parser.add_argument("--image-registry", required=True)
-    parser.add_argument("--output-dir", type=Path, required=True)
-    parser.add_argument("--timeout", type=int, default=1800)
-    parser.add_argument("--instance-ids", nargs="+", required=True)
-    args = parser.parse_args(argv)
-
-    from swebench.harness.test_spec.test_spec import make_test_spec
-    from swebench.harness.utils import (
-        get_predictions_from_file,
-        load_swebench_dataset,
-    )
-
-    from .pyxis_environment import resolve_image
-
-    predictions = {
-        prediction["instance_id"]: prediction
-        for prediction in get_predictions_from_file(
-            str(args.predictions_path), args.dataset_name, args.split
-        )
-        if prediction["instance_id"] in args.instance_ids
-    }
-    rows = load_swebench_dataset(args.dataset_name, args.split, args.instance_ids)
-    images = {
-        instance_id: resolve_image(args.image_registry, instance_id)
-        for instance_id in args.instance_ids
-    }
-    payloads = []
-    for row in rows:
-        instance_id = row["instance_id"]
-        prediction = predictions.get(instance_id)
-        if prediction is None or prediction.get("model_patch") in {"", None}:
-            continue
-        payloads.append(
-            {
-                "test_spec": make_test_spec(row, arch="arm64"),
-                "prediction": prediction,
-                "image": images[instance_id],
-                "output_dir": args.output_dir,
-                "run_id": args.run_id,
-                "timeout_s": args.timeout,
-            }
-        )
-
-    with concurrent.futures.ThreadPoolExecutor(
-        max_workers=args.max_workers
-    ) as executor:
-        futures = [
-            executor.submit(_evaluate_pyxis_instance, **payload) for payload in payloads
-        ]
-        for future in concurrent.futures.as_completed(futures):
-            try:
-                future.result()
-            except Exception as exc:
-                with _PYXIS_PRINT_LOCK:
-                    print(f"Pyxis evaluation failed: {exc}", flush=True)
-
-    _write_pyxis_run_report(
-        output_dir=args.output_dir,
-        run_id=args.run_id,
-        instance_ids=args.instance_ids,
-        predictions=predictions,
-    )
-
-
 def create_runner(
     runtime: str,
     *,
@@ -1058,20 +811,3 @@ def create_runner(
             image_registry=image_registry,
         )
     raise ValueError(f"unknown SWE-bench runtime: {runtime}")
-
-
-def _internal_main(argv: list[str] | None = None) -> None:
-    argv = sys.argv[1:] if argv is None else argv
-    if not argv:
-        raise SystemExit("expected internal command: pyxis-agent or pyxis-eval")
-    command, *command_args = argv
-    if command == "pyxis-agent":
-        _pyxis_agent_main(command_args)
-    elif command == "pyxis-eval":
-        _pyxis_eval_main(command_args)
-    else:
-        raise SystemExit(f"unknown internal command: {command}")
-
-
-if __name__ == "__main__":
-    _internal_main()

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
@@ -27,7 +27,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 from urllib.parse import urlparse, urlunparse
 
 import msgspec.json
@@ -85,6 +85,31 @@ _LOG_TAIL_MAX_BYTES = 64 * 1024
 _LOG_TAIL_MAX_LINES = 50
 _RUN_LABEL = "com.mlcommons.endpoints.swebench-run"
 _PROCESS_TERMINATE_TIMEOUT_S = 10
+_SWEBENCH_DATASETS = {
+    "verified": "princeton-nlp/SWE-bench_Verified",
+    "lite": "princeton-nlp/SWE-bench_Lite",
+}
+
+
+def _prepare_eval(request: RunRequest, run_dir: Path) -> tuple[str, str]:
+    run_id = f"endpoints_{uuid.uuid4().hex[:8]}"
+    (run_dir / "swe_bench_eval_run_id.txt").write_text(run_id)
+    dataset_name = _SWEBENCH_DATASETS.get(request.subset)
+    if dataset_name is None:
+        raise RunnerError(f"unknown SWE-bench subset: {request.subset}")
+    return run_id, dataset_name
+
+
+def _resolve_eval_result(output_dir: Path, model_name: str, run_id: str) -> Path:
+    result_path = output_dir / f"{model_name.replace('/', '__')}.{run_id}.json"
+    if result_path.exists():
+        return result_path
+    candidates = sorted(output_dir.rglob(f"*{run_id}*.json"))
+    if not candidates:
+        raise RunnerError(f"SWE-bench result file not found for run_id={run_id}")
+    if len(candidates) > 1:
+        raise RunnerError(f"multiple SWE-bench result files found for run_id={run_id}")
+    return candidates[0]
 
 
 def _normalize_endpoint_base(endpoint: str) -> str:
@@ -377,17 +402,11 @@ class SweBenchRunner:
     def _configure_environment(
         self, environment_cfg: dict[str, Any], run_id: str
     ) -> None:
-        run_args: list[str] = []
-        if docker_runtime := os.environ.get("SWEBENCH_DOCKER_RUNTIME", "").strip():
-            run_args.extend(["--runtime", docker_runtime])
-        run_args.extend(
-            [
-                "--rm",
-                "--label",
-                f"{_RUN_LABEL}={run_id}",
-            ]
-        )
-        environment_cfg["run_args"] = run_args
+        environment_cfg["run_args"] = [
+            "--rm",
+            "--label",
+            f"{_RUN_LABEL}={run_id}",
+        ]
 
     def _run_agent(
         self,
@@ -579,14 +598,7 @@ class SweBenchRunner:
         secret_values: set[str],
         cancel_token: CancellationToken | None = None,
     ) -> Path:
-        run_id = f"endpoints_{uuid.uuid4().hex[:8]}"
-        (run_dir / "swe_bench_eval_run_id.txt").write_text(run_id)
-        dataset_name = {
-            "verified": "princeton-nlp/SWE-bench_Verified",
-            "lite": "princeton-nlp/SWE-bench_Lite",
-        }.get(request.subset)
-        if dataset_name is None:
-            raise RunnerError(f"unknown SWE-bench subset: {request.subset}")
+        run_id, dataset_name = _prepare_eval(request, run_dir)
         cmd = [
             sys.executable,
             "-m",
@@ -615,18 +627,7 @@ class SweBenchRunner:
             secret_values=secret_values,
             cancel_token=cancel_token,
         )
-        safe_model = request.model_name.replace("/", "__")
-        result_path = output_dir / f"{safe_model}.{run_id}.json"
-        if result_path.exists():
-            return result_path
-        candidates = sorted(output_dir.rglob(f"*{run_id}*.json"))
-        if not candidates:
-            raise RunnerError(f"SWE-bench result file not found for run_id={run_id}")
-        if len(candidates) > 1:
-            raise RunnerError(
-                f"multiple SWE-bench result files found for run_id={run_id}"
-            )
-        return candidates[0]
+        return _resolve_eval_result(output_dir, request.model_name, run_id)
 
 
 class PyxisSweBenchRunner(SweBenchRunner):
@@ -703,14 +704,7 @@ class PyxisSweBenchRunner(SweBenchRunner):
         secret_values: set[str],
         cancel_token: CancellationToken | None = None,
     ) -> Path:
-        run_id = f"endpoints_{uuid.uuid4().hex[:8]}"
-        (run_dir / "swe_bench_eval_run_id.txt").write_text(run_id)
-        dataset_name = {
-            "verified": "princeton-nlp/SWE-bench_Verified",
-            "lite": "princeton-nlp/SWE-bench_Lite",
-        }.get(request.subset)
-        if dataset_name is None:
-            raise RunnerError(f"unknown SWE-bench subset: {request.subset}")
+        run_id, dataset_name = _prepare_eval(request, run_dir)
         command = [
             sys.executable,
             "-m",
@@ -744,12 +738,7 @@ class PyxisSweBenchRunner(SweBenchRunner):
             secret_values=secret_values,
             cancel_token=cancel_token,
         )
-        result_path = (
-            output_dir / f"{request.model_name.replace('/', '__')}.{run_id}.json"
-        )
-        if not result_path.exists():
-            raise RunnerError(f"SWE-bench result file not found for run_id={run_id}")
-        return result_path
+        return _resolve_eval_result(output_dir, request.model_name, run_id)
 
     def _cleanup_containers(
         self,
@@ -758,6 +747,7 @@ class PyxisSweBenchRunner(SweBenchRunner):
         eval_run_id: str | None = None,
         instance_ids: list[str] | None = None,
     ) -> None:
+        # Local import avoids the runner <-> Pyxis environment import cycle.
         from .pyxis_environment import build_srun_command, safe_srun_env
 
         del eval_run_id, instance_ids
@@ -791,7 +781,7 @@ class PyxisSweBenchRunner(SweBenchRunner):
 
 
 def create_runner(
-    runtime: str,
+    runtime: Literal["docker", "pyxis"],
     *,
     project_root: Path,
     subprocess_timeout_s: int,

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
@@ -15,6 +15,11 @@
 
 from __future__ import annotations
 
+import argparse
+import concurrent.futures
+import contextlib
+import copy
+import json
 import logging
 import os
 import re
@@ -85,6 +90,35 @@ _LOG_TAIL_MAX_BYTES = 64 * 1024
 _LOG_TAIL_MAX_LINES = 50
 _RUN_LABEL = "com.mlcommons.endpoints.swebench-run"
 _PROCESS_TERMINATE_TIMEOUT_S = 10
+_PYXIS_PRINT_LOCK = threading.Lock()
+_PYXIS_EVAL_SCRIPT = r"""set -eu
+
+patch_path=$1
+eval_path=$2
+output_path=$3
+timeout_s=$4
+
+cd /testbed
+if git apply --verbose "$patch_path" || \
+    git apply --verbose --reject "$patch_path" || \
+    patch --batch --fuzz=5 -p1 -i "$patch_path"; then
+    echo ">>>>> Applied Patch"
+else
+    echo ">>>>> Patch Apply Failed"
+    exit 1
+fi
+
+set +e
+timeout "$timeout_s" /bin/bash "$eval_path" >"$output_path" 2>&1
+status=$?
+set -e
+cat "$output_path"
+if [[ $status -eq 124 ]]; then
+    echo "Timeout error: $timeout_s seconds exceeded." >>"$output_path"
+    exit 124
+fi
+exit 0
+"""
 
 
 def _normalize_endpoint_base(endpoint: str) -> str:
@@ -241,7 +275,7 @@ class SweBenchRunner:
                 self._cleanup_containers(run_dir.name, **cleanup_kwargs)
             except Exception:
                 logger.warning(
-                    "Could not clean up SWE-bench Docker containers for run %s",
+                    "Could not clean up SWE-bench containers for run %s",
                     run_dir.name,
                     exc_info=True,
                 )
@@ -366,17 +400,28 @@ class SweBenchRunner:
         environment_cfg = cfg.get("environment")
         if not isinstance(environment_cfg, dict):
             raise RunnerError("swebench template must define environment")
-        environment_cfg["run_args"] = [
-            "--rm",
-            "--label",
-            f"{_RUN_LABEL}={run_id}",
-        ]
+        self._configure_environment(environment_cfg, run_id)
 
         config_dir.mkdir(parents=True, exist_ok=True)
         patched_path = config_dir / "swebench_patched.yaml"
         with patched_path.open("w") as f:
             yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
         return patched_path
+
+    def _configure_environment(
+        self, environment_cfg: dict[str, Any], run_id: str
+    ) -> None:
+        run_args: list[str] = []
+        if docker_runtime := os.environ.get("SWEBENCH_DOCKER_RUNTIME", "").strip():
+            run_args.extend(["--runtime", docker_runtime])
+        run_args.extend(
+            [
+                "--rm",
+                "--label",
+                f"{_RUN_LABEL}={run_id}",
+            ]
+        )
+        environment_cfg["run_args"] = run_args
 
     def _run_agent(
         self,
@@ -616,3 +661,417 @@ class SweBenchRunner:
                 f"multiple SWE-bench result files found for run_id={run_id}"
             )
         return candidates[0]
+
+
+class PyxisSweBenchRunner(SweBenchRunner):
+    def __init__(
+        self,
+        *,
+        project_root: Path,
+        subprocess_timeout_s: int,
+        image_registry: str,
+    ):
+        super().__init__(
+            project_root=project_root,
+            subprocess_timeout_s=subprocess_timeout_s,
+        )
+        self.image_registry = image_registry
+
+    def _configure_environment(
+        self, environment_cfg: dict[str, Any], run_id: str
+    ) -> None:
+        for key in ("run_args", "pull_timeout", "container_timeout"):
+            environment_cfg.pop(key, None)
+        environment_cfg["environment_class"] = (
+            "swebench_service.pyxis_environment.PyxisEnvironment"
+        )
+        environment_cfg["run_id"] = run_id
+
+    def _run_agent(
+        self,
+        request: RunRequest,
+        patched_config: Path,
+        output_dir: Path,
+        run_dir: Path,
+        secret_values: set[str],
+        cancel_token: CancellationToken | None = None,
+    ) -> None:
+        command = [
+            sys.executable,
+            "-m",
+            "swebench_service.runner",
+            "pyxis-agent",
+            "--model",
+            request.model_name,
+            "--config",
+            str(patched_config),
+            "--subset",
+            request.subset,
+            "--split",
+            request.split,
+            "--filter",
+            _exact_instance_filter(request.evaluated_instance_ids),
+            "--workers",
+            str(request.workers),
+            "--output",
+            str(output_dir),
+            "--image-registry",
+            self.image_registry,
+        ]
+        self._run_logged_subprocess(
+            command,
+            run_dir / "swe_bench_agent.log",
+            cwd=output_dir,
+            timeout_s=self.subprocess_timeout_s,
+            env=self._base_env(request),
+            secret_values=secret_values,
+            cancel_token=cancel_token,
+        )
+
+    def _run_eval(
+        self,
+        request: RunRequest,
+        preds_path: Path,
+        output_dir: Path,
+        run_dir: Path,
+        secret_values: set[str],
+        cancel_token: CancellationToken | None = None,
+    ) -> Path:
+        run_id = f"endpoints_{uuid.uuid4().hex[:8]}"
+        (run_dir / "swe_bench_eval_run_id.txt").write_text(run_id)
+        dataset_name = {
+            "verified": "princeton-nlp/SWE-bench_Verified",
+            "lite": "princeton-nlp/SWE-bench_Lite",
+        }.get(request.subset)
+        if dataset_name is None:
+            raise RunnerError(f"unknown SWE-bench subset: {request.subset}")
+        command = [
+            sys.executable,
+            "-m",
+            "swebench_service.runner",
+            "pyxis-eval",
+            "--dataset-name",
+            dataset_name,
+            "--split",
+            request.split,
+            "--predictions-path",
+            str(preds_path),
+            "--max-workers",
+            str(request.max_eval_workers),
+            "--run-id",
+            run_id,
+            "--image-registry",
+            self.image_registry,
+            "--output-dir",
+            str(output_dir),
+            "--instance-ids",
+            *request.evaluated_instance_ids,
+        ]
+        env = dict(os.environ)
+        env.pop("OPENAI_API_KEY", None)
+        self._run_logged_subprocess(
+            command,
+            run_dir / "swe_bench_eval.log",
+            cwd=output_dir,
+            timeout_s=self.subprocess_timeout_s,
+            env=env,
+            secret_values=secret_values,
+            cancel_token=cancel_token,
+        )
+        result_path = (
+            output_dir / f"{request.model_name.replace('/', '__')}.{run_id}.json"
+        )
+        if not result_path.exists():
+            raise RunnerError(f"SWE-bench result file not found for run_id={run_id}")
+        return result_path
+
+    def _cleanup_containers(
+        self,
+        run_id: str,
+        *,
+        eval_run_id: str | None = None,
+        instance_ids: list[str] | None = None,
+    ) -> None:
+        from .pyxis_environment import build_host_srun_command, safe_srun_env
+
+        del eval_run_id, instance_ids
+        safe_run_id = re.sub(r"[^A-Za-z0-9_.-]", "-", run_id)[:24]
+        prefix = f"pyxis_mswe_{safe_run_id}_"
+        try:
+            listed = subprocess.run(
+                build_host_srun_command(["enroot", "list", "-f"]),
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=safe_srun_env(),
+            )
+            for line in listed.stdout.splitlines():
+                fields = line.split(maxsplit=1)
+                name = fields[0] if fields else ""
+                if name.startswith(prefix):
+                    subprocess.run(
+                        build_host_srun_command(["enroot", "remove", "-f", name]),
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        env=safe_srun_env(),
+                    )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise RunnerError(
+                f"failed to clean up Pyxis containers for SWE-bench run {run_id}"
+            ) from exc
+
+
+def _enable_live_trajectory_saves(swebench: Any, output_dir: Path) -> None:
+    base_agent = swebench.ProgressTrackingAgent
+
+    class LiveTrajectoryAgent(base_agent):  # type: ignore[misc, valid-type]
+        def __init__(self, *args: Any, instance_id: str = "", **kwargs: Any):
+            kwargs["output_path"] = (
+                output_dir / instance_id / f"{instance_id}.live.json"
+            )
+            super().__init__(*args, instance_id=instance_id, **kwargs)
+
+    swebench.ProgressTrackingAgent = LiveTrajectoryAgent
+
+
+def _pyxis_agent_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--subset", required=True)
+    parser.add_argument("--split", required=True)
+    parser.add_argument("--filter", required=True)
+    parser.add_argument("--workers", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--image-registry", required=True)
+    args = parser.parse_args(argv)
+
+    from minisweagent.environments import get_environment
+    from minisweagent.run.benchmarks import swebench
+
+    from .pyxis_environment import resolve_image
+
+    def get_pyxis_environment(config: dict, instance: dict):
+        environment_config = copy.deepcopy(config.get("environment", {}))
+        environment_config["image"] = resolve_image(
+            args.image_registry, instance["instance_id"]
+        )
+        return get_environment(environment_config)
+
+    swebench.get_sb_environment = get_pyxis_environment
+    _enable_live_trajectory_saves(swebench, args.output)
+    swebench.main(
+        subset=args.subset,
+        split=args.split,
+        slice_spec="",
+        filter_spec=args.filter,
+        shuffle=False,
+        output=str(args.output),
+        workers=args.workers,
+        model=args.model,
+        model_class=None,
+        redo_existing=False,
+        config_spec=[str(args.config)],
+        environment_class=("swebench_service.pyxis_environment.PyxisEnvironment"),
+    )
+
+
+def _write_pyxis_run_report(
+    *,
+    output_dir: Path,
+    run_id: str,
+    instance_ids: list[str],
+    predictions: dict[str, dict[str, Any]],
+) -> Path:
+    from swebench.harness.reporting import make_run_report
+
+    output_dir = output_dir.resolve()
+    with contextlib.chdir(output_dir):
+        result_path = make_run_report(
+            predictions,
+            [{"instance_id": instance_id} for instance_id in instance_ids],
+            run_id,
+            client=None,
+        )
+    return output_dir / result_path
+
+
+def _evaluate_pyxis_instance(
+    *,
+    test_spec: Any,
+    prediction: dict[str, Any],
+    image: str | Path,
+    output_dir: Path,
+    run_id: str,
+    timeout_s: int,
+) -> None:
+    from .pyxis_environment import build_srun_command, safe_srun_env
+
+    instance_id = test_spec.instance_id
+    safe_model = prediction["model_name_or_path"].replace("/", "__")
+    log_dir = output_dir / "logs" / "run_evaluation" / run_id / safe_model / instance_id
+    log_dir.mkdir(parents=True, exist_ok=True)
+    patch_path = log_dir / "patch.diff"
+    eval_path = log_dir / "eval.sh"
+    output_path = log_dir / "test_output.txt"
+    report_path = log_dir / "report.json"
+    patch_path.write_text(prediction["model_patch"])
+    eval_path.write_text(test_spec.eval_script)
+    output_path.write_text("")
+    report_path.unlink(missing_ok=True)
+
+    command = build_srun_command(
+        image=image,
+        name=None,
+        mounts=[
+            (patch_path, "/tmp/swebench_patch.diff"),
+            (eval_path, "/tmp/swebench_eval.sh"),
+            (output_path, "/tmp/swebench_test_output.txt"),
+        ],
+        workdir="/testbed",
+        argv=[
+            "bash",
+            "-c",
+            _PYXIS_EVAL_SCRIPT,
+            "pyxis-eval",
+            "/tmp/swebench_patch.diff",
+            "/tmp/swebench_eval.sh",
+            "/tmp/swebench_test_output.txt",
+            str(timeout_s),
+        ],
+    )
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s + 60,
+        env=safe_srun_env(),
+    )
+    with _PYXIS_PRINT_LOCK:
+        print(f"[{instance_id}]\n{result.stdout}{result.stderr}", flush=True)
+    if result.returncode != 0:
+        return
+
+    from swebench.harness.grading import get_eval_report
+
+    report = get_eval_report(
+        test_spec=test_spec,
+        prediction=prediction,
+        test_log_path=output_path,
+        include_tests_status=True,
+    )
+    atomic_write_bytes(report_path, (json.dumps(report, indent=4) + "\n").encode())
+
+
+def _pyxis_eval_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-name", required=True)
+    parser.add_argument("--split", required=True)
+    parser.add_argument("--predictions-path", type=Path, required=True)
+    parser.add_argument("--max-workers", type=int, required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--image-registry", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--timeout", type=int, default=1800)
+    parser.add_argument("--instance-ids", nargs="+", required=True)
+    args = parser.parse_args(argv)
+
+    from swebench.harness.test_spec.test_spec import make_test_spec
+    from swebench.harness.utils import (
+        get_predictions_from_file,
+        load_swebench_dataset,
+    )
+
+    from .pyxis_environment import resolve_image
+
+    predictions = {
+        prediction["instance_id"]: prediction
+        for prediction in get_predictions_from_file(
+            str(args.predictions_path), args.dataset_name, args.split
+        )
+        if prediction["instance_id"] in args.instance_ids
+    }
+    rows = load_swebench_dataset(args.dataset_name, args.split, args.instance_ids)
+    images = {
+        instance_id: resolve_image(args.image_registry, instance_id)
+        for instance_id in args.instance_ids
+    }
+    payloads = []
+    for row in rows:
+        instance_id = row["instance_id"]
+        prediction = predictions.get(instance_id)
+        if prediction is None or prediction.get("model_patch") in {"", None}:
+            continue
+        payloads.append(
+            {
+                "test_spec": make_test_spec(row, arch="arm64"),
+                "prediction": prediction,
+                "image": images[instance_id],
+                "output_dir": args.output_dir,
+                "run_id": args.run_id,
+                "timeout_s": args.timeout,
+            }
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=args.max_workers
+    ) as executor:
+        futures = [
+            executor.submit(_evaluate_pyxis_instance, **payload) for payload in payloads
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                future.result()
+            except Exception as exc:
+                with _PYXIS_PRINT_LOCK:
+                    print(f"Pyxis evaluation failed: {exc}", flush=True)
+
+    _write_pyxis_run_report(
+        output_dir=args.output_dir,
+        run_id=args.run_id,
+        instance_ids=args.instance_ids,
+        predictions=predictions,
+    )
+
+
+def create_runner(
+    runtime: str,
+    *,
+    project_root: Path,
+    subprocess_timeout_s: int,
+    image_registry: str | None,
+) -> RunnerProtocol:
+    if runtime == "docker":
+        return SweBenchRunner(
+            project_root=project_root,
+            subprocess_timeout_s=subprocess_timeout_s,
+        )
+    if runtime == "pyxis":
+        if image_registry is None:
+            raise ValueError("Pyxis runtime requires an image registry")
+        return PyxisSweBenchRunner(
+            project_root=project_root,
+            subprocess_timeout_s=subprocess_timeout_s,
+            image_registry=image_registry,
+        )
+    raise ValueError(f"unknown SWE-bench runtime: {runtime}")
+
+
+def _internal_main(argv: list[str] | None = None) -> None:
+    argv = sys.argv[1:] if argv is None else argv
+    if not argv:
+        raise SystemExit("expected internal command: pyxis-agent or pyxis-eval")
+    command, *command_args = argv
+    if command == "pyxis-agent":
+        _pyxis_agent_main(command_args)
+    elif command == "pyxis-eval":
+        _pyxis_eval_main(command_args)
+    else:
+        raise SystemExit(f"unknown internal command: {command}")
+
+
+if __name__ == "__main__":
+    _internal_main()

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/runner.py
@@ -792,14 +792,14 @@ class PyxisSweBenchRunner(SweBenchRunner):
         eval_run_id: str | None = None,
         instance_ids: list[str] | None = None,
     ) -> None:
-        from .pyxis_environment import build_host_srun_command, safe_srun_env
+        from .pyxis_environment import build_srun_command, safe_srun_env
 
         del eval_run_id, instance_ids
         safe_run_id = re.sub(r"[^A-Za-z0-9_.-]", "-", run_id)[:24]
         prefix = f"pyxis_mswe_{safe_run_id}_"
         try:
             listed = subprocess.run(
-                build_host_srun_command(["enroot", "list", "-f"]),
+                build_srun_command(argv=["enroot", "list", "-f"]),
                 check=True,
                 capture_output=True,
                 text=True,
@@ -811,7 +811,7 @@ class PyxisSweBenchRunner(SweBenchRunner):
                 name = fields[0] if fields else ""
                 if name.startswith(prefix):
                     subprocess.run(
-                        build_host_srun_command(["enroot", "remove", "-f", name]),
+                        build_srun_command(argv=["enroot", "remove", "-f", name]),
                         check=True,
                         capture_output=True,
                         text=True,

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/templates/swebench_template.yaml
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/templates/swebench_template.yaml
@@ -126,7 +126,7 @@ environment:
     TQDM_DISABLE: "1"
   environment_class: docker
   pull_timeout: 3600
-  container_timeout: 10h
+  container_timeout: 6h
 
 model:
   cost_tracking: "ignore_errors"
@@ -180,8 +180,8 @@ model:
   model_kwargs:
     custom_llm_provider: "openai"
     drop_params: true
-    parallel_tool_calls: true
     api_base: ""
+    timeout: 3600
     # Sampling parameters (temperature, top_p, top_k, etc.) are injected at
     # runtime from the benchmark config's model_params block — absent here so
     # the model's own defaults apply when not specified in model_params.

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/templates/swebench_template.yaml
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/templates/swebench_template.yaml
@@ -126,7 +126,7 @@ environment:
     TQDM_DISABLE: "1"
   environment_class: docker
   pull_timeout: 3600
-  container_timeout: 6h
+  container_timeout: 10h
 
 model:
   cost_tracking: "ignore_errors"

--- a/tests/unit/evaluation/swebench_service/test_runner.py
+++ b/tests/unit/evaluation/swebench_service/test_runner.py
@@ -7,10 +7,12 @@ import sys
 import threading
 import types
 from pathlib import Path
+from typing import Literal, get_type_hints
 
 import msgspec.json
 import pytest
 import yaml
+
 from inference_endpoint.evaluation.swebench_service.swebench_service import (
     pyxis_worker as worker_mod,
 )
@@ -212,26 +214,6 @@ def test_patch_config_normalizes_api_base(tmp_path, endpoint, expected_api_base)
     assert "model_class" not in cfg["model"]
     assert "api_key" not in cfg["model"]["model_kwargs"]
     assert cfg["environment"]["run_args"] == [
-        "--rm",
-        "--label",
-        "com.mlcommons.endpoints.swebench-run=run-123",
-    ]
-
-
-def test_patch_config_uses_requested_docker_runtime(monkeypatch, tmp_path):
-    monkeypatch.setenv("SWEBENCH_DOCKER_RUNTIME", "runc")
-    runner = SweBenchRunner(project_root=tmp_path, subprocess_timeout_s=30)
-
-    patched = runner._patch_config(
-        tmp_path,
-        _request(["http://localhost:30000"]),
-        run_id="run-123",
-    )
-
-    cfg = yaml.safe_load(patched.read_text())
-    assert cfg["environment"]["run_args"] == [
-        "--runtime",
-        "runc",
         "--rm",
         "--label",
         "com.mlcommons.endpoints.swebench-run=run-123",
@@ -622,6 +604,63 @@ def _pyxis_request(instance_ids: list[str] | None = None) -> RunRequest:
 _PYXIS_IMAGE_REGISTRY = "gitlab-master.nvidia.com:5005/hvagadia/swebench-arm64-images"
 
 
+def _finish_srun_step(command: list[str], returncode: int) -> None:
+    mount_argument = next(
+        (
+            argument
+            for argument in command
+            if argument.startswith("--container-mounts=")
+        ),
+        None,
+    )
+    if mount_argument is None:
+        return
+    for mount in mount_argument.removeprefix("--container-mounts=").split(","):
+        source, destination = mount.split(":", 1)
+        if destination == "/tmp/.mlperf_srun_status":
+            Path(source).write_text(f"finished:{returncode}\n")
+            return
+        if destination == "/tmp":
+            Path(source, ".mlperf_srun_status").write_text(f"finished:{returncode}\n")
+            return
+    raise AssertionError("srun command does not mount its status file")
+
+
+def _install_fake_minisweagent(monkeypatch, swebench) -> None:
+    minisweagent = types.ModuleType("minisweagent")
+    environments = types.ModuleType("minisweagent.environments")
+    environments.get_environment = lambda config: config  # type: ignore[attr-defined]
+    run = types.ModuleType("minisweagent.run")
+    benchmarks = types.ModuleType("minisweagent.run.benchmarks")
+    benchmarks.swebench = swebench  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "minisweagent", minisweagent)
+    monkeypatch.setitem(sys.modules, "minisweagent.environments", environments)
+    monkeypatch.setitem(sys.modules, "minisweagent.run", run)
+    monkeypatch.setitem(sys.modules, "minisweagent.run.benchmarks", benchmarks)
+
+
+def _pyxis_agent_args(tmp_path) -> list[str]:
+    return [
+        "agent",
+        "--model",
+        "test-model",
+        "--config",
+        str(tmp_path / "config.yaml"),
+        "--subset",
+        "verified",
+        "--split",
+        "test",
+        "--filter",
+        "repo__repo-1",
+        "--workers",
+        "1",
+        "--output",
+        str(tmp_path),
+        "--image-registry",
+        _PYXIS_IMAGE_REGISTRY,
+    ]
+
+
 def test_create_runner_defaults_to_docker(tmp_path):
     runner = create_runner(
         "docker",
@@ -631,6 +670,10 @@ def test_create_runner_defaults_to_docker(tmp_path):
     )
 
     assert type(runner) is SweBenchRunner
+
+
+def test_create_runner_runtime_is_typed():
+    assert get_type_hints(create_runner)["runtime"] == Literal["docker", "pyxis"]
 
 
 def test_create_runner_requires_image_registry_for_pyxis(tmp_path):
@@ -683,6 +726,17 @@ def test_pyxis_resolves_registry_image_from_instance_id():
         resolve_image(_PYXIS_IMAGE_REGISTRY, "../repo__repo-1")
 
 
+def test_pyxis_normalizes_instance_id_for_registry_image():
+    assert resolve_image(_PYXIS_IMAGE_REGISTRY, "Repo__Repo-1").endswith(
+        "/sweb.eval.arm64.repo__repo-1:v4.1.0-arm64"
+    )
+
+
+def test_pyxis_image_registry_requires_repository():
+    with pytest.raises(RunnerError, match="must include a repository"):
+        resolve_image("registry.example.com", "repo__repo-1")
+
+
 def test_pyxis_builds_one_node_srun_command(monkeypatch, tmp_path):
     image = resolve_image(_PYXIS_IMAGE_REGISTRY, "repo__repo-1")
     source = tmp_path / "input.json"
@@ -717,6 +771,18 @@ def test_pyxis_builds_one_node_srun_command(monkeypatch, tmp_path):
     ]
 
 
+def test_pyxis_rejects_commas_in_mount_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+
+    with pytest.raises(RunnerError, match="mount paths cannot contain commas"):
+        build_srun_command(
+            image="registry.example.com#images/task:latest",
+            mounts=[(tmp_path / "input,with-comma.json", "/tmp/input.json")],
+            argv=["true"],
+        )
+
+
 def test_pyxis_srun_requires_allocation(monkeypatch, tmp_path):
     monkeypatch.delenv("SLURM_JOB_ID", raising=False)
 
@@ -728,6 +794,14 @@ def test_pyxis_srun_requires_allocation(monkeypatch, tmp_path):
             workdir="/testbed",
             argv=["true"],
         )
+
+
+def test_pyxis_srun_requires_current_node(monkeypatch):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.delenv("SLURMD_NODENAME", raising=False)
+
+    with pytest.raises(RunnerError, match="SLURMD_NODENAME"):
+        build_srun_command(argv=["true"])
 
 
 def test_pyxis_builds_host_srun_command(monkeypatch):
@@ -771,6 +845,7 @@ def test_pyxis_environment_reuses_named_writable_container(monkeypatch, tmp_path
 
     def fake_run(command, **kwargs):
         calls.append((command, kwargs))
+        _finish_srun_step(command, 0)
         return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -817,6 +892,7 @@ def test_pyxis_environment_mounts_persistent_tmp_on_every_step(monkeypatch, tmp_
 
     def fake_run(command, **kwargs):
         calls.append(command)
+        _finish_srun_step(command, 0)
         return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -842,13 +918,129 @@ def test_pyxis_environment_mounts_persistent_tmp_on_every_step(monkeypatch, tmp_
     assert not persistent_tmp.exists()
 
 
-def test_pyxis_cleanup_is_best_effort_outside_allocation(monkeypatch, tmp_path):
+def test_pyxis_environment_extracts_submission(monkeypatch, tmp_path):
+    class Submitted(Exception):
+        pass
+
+    minisweagent = types.ModuleType("minisweagent")
+    exceptions = types.ModuleType("minisweagent.exceptions")
+    exceptions.Submitted = Submitted
+    monkeypatch.setitem(sys.modules, "minisweagent", minisweagent)
+    monkeypatch.setitem(sys.modules, "minisweagent.exceptions", exceptions)
     monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+    calls = 0
+
+    def fake_run(command, **kwargs):
+        nonlocal calls
+        calls += 1
+        output = (
+            "ok\n"
+            if calls == 1
+            else "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\ndiff --git a/a b/a\n"
+        )
+        _finish_srun_step(command, 0)
+        return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    environment = PyxisEnvironment(image=tmp_path / "task.sqsh", run_id="run-1")
+
+    with pytest.raises(Submitted) as exc_info:
+        environment.execute({"command": "submit"})
+
+    assert exc_info.value.args[0]["extra"]["submission"] == "diff --git a/a b/a\n"
+    environment.cleanup()
+
+
+def test_pyxis_environment_decodes_timeout_output(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+    calls = 0
+
+    def fake_run(command, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            _finish_srun_step(command, 124)
+            return subprocess.CompletedProcess(
+                command, 124, stdout="partial�", stderr=""
+            )
+        _finish_srun_step(command, 0)
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    environment = PyxisEnvironment(image=tmp_path / "task.sqsh", run_id="run-1")
+
+    output = environment.execute({"command": "sleep 60"})
+
+    assert output["returncode"] == -1
+    assert output["output"] == "partial�"
+    assert output["extra"]["exception_type"] == "TimeoutExpired"
+    environment.cleanup()
+
+
+def test_pyxis_environment_raises_when_srun_never_starts_command(monkeypatch, tmp_path):
+    failure_path = tmp_path / ".pyxis_infrastructure_failure"
+    environment = object.__new__(PyxisEnvironment)
+    environment.config = types.SimpleNamespace(
+        cwd="/testbed",
+        env={},
+        timeout=30,
+        interpreter=["bash", "-c"],
+        infrastructure_failure_path=failure_path,
+    )
+    environment.name = "mswe_run-1_abcd1234"
+    environment._tmp_dir = tmp_path
+
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, stdout=""),
+        lambda command, **kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(command, 30)
+        ),
     )
+
+    with pytest.raises(RunnerError, match="before the command completed"):
+        environment.execute({"command": "pytest -q"})
+
+    assert failure_path.exists()
+
+
+def test_pyxis_environment_preserves_command_failure(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+    calls = 0
+
+    def fake_run(command, **kwargs):
+        nonlocal calls
+        calls += 1
+        returncode = 0 if calls == 1 else 1
+        _finish_srun_step(command, returncode)
+        return subprocess.CompletedProcess(
+            command, returncode, stdout="command failed\n", stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    environment = PyxisEnvironment(image=tmp_path / "task.sqsh", run_id="run-1")
+
+    output = environment.execute({"command": "false"})
+
+    assert output["returncode"] == 1
+    assert output["output"] == "command failed\n"
+    environment.cleanup()
+
+
+def test_pyxis_cleanup_is_best_effort_outside_allocation(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+
+    def fake_run(command, **kwargs):
+        _finish_srun_step(command, 0)
+        return subprocess.CompletedProcess(command, 0, stdout="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
     image = tmp_path / "task.sqsh"
     image.touch()
     environment = PyxisEnvironment(image=image, run_id="run-1")
@@ -860,8 +1052,22 @@ def test_pyxis_cleanup_is_best_effort_outside_allocation(monkeypatch, tmp_path):
     assert not persistent_tmp.exists()
 
 
+def test_pyxis_finalizer_logs_cleanup_failure(monkeypatch, caplog):
+    environment = object.__new__(PyxisEnvironment)
+
+    def fail_cleanup():
+        raise OSError("cleanup failed")
+
+    monkeypatch.setattr(environment, "cleanup", fail_cleanup)
+
+    environment.__del__()
+
+    assert "Could not clean up Pyxis environment" in caplog.text
+
+
 def test_pyxis_start_failure_removes_persistent_tmp(monkeypatch, tmp_path):
     monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
     image = tmp_path / "task.sqsh"
     image.touch()
     persistent_tmp: Path | None = None
@@ -949,59 +1155,43 @@ def test_pyxis_agent_command_uses_host_model_and_image_registry(monkeypatch, tmp
     assert kwargs["env"]["OPENAI_API_KEY"] == "model-secret"
 
 
-def test_pyxis_agent_saves_each_live_trajectory_to_its_instance_path(
-    monkeypatch, tmp_path
-):
-    class FakeProgressTrackingAgent:
-        def __init__(self, *args, instance_id="", **kwargs):
-            self.instance_id = instance_id
-            self.kwargs = kwargs
+def test_pyxis_agent_requires_upstream_environment_hook(monkeypatch, tmp_path):
+    swebench = types.SimpleNamespace(main=lambda **kwargs: None)
+    _install_fake_minisweagent(monkeypatch, swebench)
 
+    with pytest.raises(RuntimeError, match="get_sb_environment"):
+        worker_mod.main(_pyxis_agent_args(tmp_path))
+
+
+def test_pyxis_agent_restores_upstream_environment_hook(monkeypatch, tmp_path):
+    original = object()
     swebench = types.SimpleNamespace(
-        ProgressTrackingAgent=FakeProgressTrackingAgent,
+        get_sb_environment=original,
         main=lambda **kwargs: None,
     )
-    minisweagent = types.ModuleType("minisweagent")
-    environments = types.ModuleType("minisweagent.environments")
-    environments.get_environment = lambda config: config
-    run = types.ModuleType("minisweagent.run")
-    benchmarks = types.ModuleType("minisweagent.run.benchmarks")
-    benchmarks.swebench = swebench
-    monkeypatch.setitem(sys.modules, "minisweagent", minisweagent)
-    monkeypatch.setitem(sys.modules, "minisweagent.environments", environments)
-    monkeypatch.setitem(sys.modules, "minisweagent.run", run)
-    monkeypatch.setitem(sys.modules, "minisweagent.run.benchmarks", benchmarks)
+    _install_fake_minisweagent(monkeypatch, swebench)
 
-    worker_mod.main(
-        [
-            "agent",
-            "--model",
-            "test-model",
-            "--config",
-            str(tmp_path / "config.yaml"),
-            "--subset",
-            "verified",
-            "--split",
-            "test",
-            "--filter",
-            "repo__repo-1",
-            "--workers",
-            "1",
-            "--output",
-            str(tmp_path),
-            "--image-registry",
-            _PYXIS_IMAGE_REGISTRY,
-        ]
-    )
-    first = swebench.ProgressTrackingAgent(instance_id="repo__repo-1")
-    second = swebench.ProgressTrackingAgent(instance_id="repo__repo-2")
+    worker_mod.main(_pyxis_agent_args(tmp_path))
 
-    assert first.kwargs["output_path"] == (
-        tmp_path / "repo__repo-1" / "repo__repo-1.live.json"
+    assert swebench.get_sb_environment is original
+
+
+def test_pyxis_agent_propagates_environment_infrastructure_failure(
+    monkeypatch, tmp_path
+):
+    original = object()
+
+    def fake_main(**kwargs):
+        (tmp_path / ".pyxis_infrastructure_failure").touch()
+
+    swebench = types.SimpleNamespace(
+        get_sb_environment=original,
+        main=fake_main,
     )
-    assert second.kwargs["output_path"] == (
-        tmp_path / "repo__repo-2" / "repo__repo-2.live.json"
-    )
+    _install_fake_minisweagent(monkeypatch, swebench)
+
+    with pytest.raises(RunnerError, match="infrastructure failure"):
+        worker_mod.main(_pyxis_agent_args(tmp_path))
 
 
 def test_pyxis_eval_command_does_not_forward_model_key(monkeypatch, tmp_path):
@@ -1039,8 +1229,35 @@ def test_pyxis_eval_command_does_not_forward_model_key(monkeypatch, tmp_path):
     assert result.exists()
 
 
+def test_pyxis_eval_finds_nested_result(monkeypatch, tmp_path):
+    output_dir = tmp_path / "output"
+    run_dir = tmp_path / "run"
+    output_dir.mkdir()
+    run_dir.mkdir()
+    preds_path = output_dir / "preds.json"
+    preds_path.write_text("{}")
+
+    def fake_run(command, log_path, *, cwd, **kwargs):
+        run_id = command[command.index("--run-id") + 1]
+        nested = cwd / "nested"
+        nested.mkdir()
+        (nested / f"result.{run_id}.json").write_text("{}")
+
+    monkeypatch.setattr(runner_mod, "_run_subprocess", fake_run)
+    runner = PyxisSweBenchRunner(
+        project_root=tmp_path,
+        subprocess_timeout_s=30,
+        image_registry=_PYXIS_IMAGE_REGISTRY,
+    )
+
+    result = runner._run_eval(_pyxis_request(), preds_path, output_dir, run_dir, set())
+
+    assert result.parent.name == "nested"
+
+
 def test_pyxis_eval_does_not_mount_report_directory(monkeypatch, tmp_path):
     monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
     image = tmp_path / "task.sqsh"
     image.touch()
     report = (
@@ -1058,6 +1275,7 @@ def test_pyxis_eval_does_not_mount_report_directory(monkeypatch, tmp_path):
 
     def fake_run(command, **kwargs):
         calls.append(command)
+        _finish_srun_step(command, 1)
         return subprocess.CompletedProcess(command, 1, stdout="", stderr="failed")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1079,6 +1297,48 @@ def test_pyxis_eval_does_not_mount_report_directory(monkeypatch, tmp_path):
     assert "report.json" not in mounts
     assert f"{report.parent.resolve()}:/" not in mounts
     assert not report.exists()
+
+
+def test_pyxis_evaluate_instance_writes_upstream_report(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+    grading = types.ModuleType("swebench.harness.grading")
+    grading.get_eval_report = lambda **kwargs: {"repo__repo-1": {"resolved": True}}
+    swebench = types.ModuleType("swebench")
+    harness = types.ModuleType("swebench.harness")
+    monkeypatch.setitem(sys.modules, "swebench", swebench)
+    monkeypatch.setitem(sys.modules, "swebench.harness", harness)
+    monkeypatch.setitem(sys.modules, "swebench.harness.grading", grading)
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        _finish_srun_step(command, 0)
+        return subprocess.CompletedProcess(command, 0, stdout="tests passed", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    worker_mod._evaluate_instance(
+        test_spec=types.SimpleNamespace(
+            instance_id="repo__repo-1", eval_script="pytest -q"
+        ),
+        prediction={
+            "model_name_or_path": "test-model",
+            "model_patch": "diff --git a/a b/a",
+        },
+        image=tmp_path / "task.sqsh",
+        output_dir=tmp_path,
+        run_id="run-1",
+        timeout_s=30,
+    )
+
+    report = tmp_path / "logs/run_evaluation/run-1/test-model/repo__repo-1/report.json"
+    assert msgspec.json.decode(report.read_bytes()) == {
+        "repo__repo-1": {"resolved": True}
+    }
+    mounts = next(arg for arg in calls[0] if arg.startswith("--container-mounts="))
+    assert "patch.diff:/tmp/swebench_patch.diff" in mounts
+    assert "eval.sh:/tmp/swebench_eval.sh" in mounts
+    assert "test_output.txt:/tmp/swebench_test_output.txt" in mounts
 
 
 def test_pyxis_worker_uses_upstream_report(monkeypatch, tmp_path):
@@ -1161,3 +1421,68 @@ def test_pyxis_worker_uses_upstream_report(monkeypatch, tmp_path):
             None,
         )
     ]
+
+
+def test_pyxis_worker_propagates_evaluation_infrastructure_failure(
+    monkeypatch, tmp_path
+):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    predictions = {
+        "repo__repo-1": {
+            "model_name_or_path": "test-model",
+            "instance_id": "repo__repo-1",
+            "model_patch": "diff --git a/a b/a",
+        }
+    }
+
+    swebench = types.ModuleType("swebench")
+    harness = types.ModuleType("swebench.harness")
+    reporting = types.ModuleType("swebench.harness.reporting")
+    reporting.make_run_report = lambda *args, **kwargs: None
+    test_spec = types.ModuleType("swebench.harness.test_spec")
+    test_spec_module = types.ModuleType("swebench.harness.test_spec.test_spec")
+    test_spec_module.make_test_spec = lambda row, arch: types.SimpleNamespace(
+        instance_id=row["instance_id"], eval_script="pytest -q"
+    )
+    utils = types.ModuleType("swebench.harness.utils")
+    utils.get_predictions_from_file = lambda *args: predictions.values()
+    utils.load_swebench_dataset = lambda *args: [{"instance_id": "repo__repo-1"}]
+    monkeypatch.setitem(sys.modules, "swebench", swebench)
+    monkeypatch.setitem(sys.modules, "swebench.harness", harness)
+    monkeypatch.setitem(sys.modules, "swebench.harness.reporting", reporting)
+    monkeypatch.setitem(sys.modules, "swebench.harness.test_spec", test_spec)
+    monkeypatch.setitem(
+        sys.modules, "swebench.harness.test_spec.test_spec", test_spec_module
+    )
+    monkeypatch.setitem(sys.modules, "swebench.harness.utils", utils)
+    monkeypatch.setattr(
+        worker_mod,
+        "_evaluate_instance",
+        lambda **kwargs: (_ for _ in ()).throw(
+            RunnerError("Pyxis infrastructure failure")
+        ),
+    )
+
+    with pytest.raises(RunnerError, match="repo__repo-1"):
+        worker_mod.main(
+            [
+                "eval",
+                "--dataset-name",
+                "princeton-nlp/SWE-bench_Verified",
+                "--split",
+                "test",
+                "--predictions-path",
+                str(output_dir / "preds.json"),
+                "--max-workers",
+                "1",
+                "--run-id",
+                "endpoints_test",
+                "--image-registry",
+                _PYXIS_IMAGE_REGISTRY,
+                "--output-dir",
+                str(output_dir),
+                "--instance-ids",
+                "repo__repo-1",
+            ]
+        )

--- a/tests/unit/evaluation/swebench_service/test_runner.py
+++ b/tests/unit/evaluation/swebench_service/test_runner.py
@@ -12,6 +12,9 @@ import msgspec.json
 import pytest
 import yaml
 from inference_endpoint.evaluation.swebench_service.swebench_service import (
+    pyxis_worker as worker_mod,
+)
+from inference_endpoint.evaluation.swebench_service.swebench_service import (
     runner as runner_mod,
 )
 from inference_endpoint.evaluation.swebench_service.swebench_service.pyxis_environment import (
@@ -26,8 +29,6 @@ from inference_endpoint.evaluation.swebench_service.swebench_service.runner impo
     RunCancelled,
     RunnerError,
     SweBenchRunner,
-    _evaluate_pyxis_instance,
-    _write_pyxis_run_report,
     create_runner,
 )
 from inference_endpoint.evaluation.swebench_service.swebench_service.schemas import (
@@ -37,11 +38,12 @@ from inference_endpoint.evaluation.swebench_service.swebench_service.schemas imp
 pytestmark = pytest.mark.unit
 
 
-def test_pyxis_implementation_adds_only_environment_module():
+def test_pyxis_implementation_is_confined_to_environment_and_worker_modules():
     package_dir = Path(runner_mod.__file__).parent
 
     assert {path.name for path in package_dir.glob("pyxis_*") if path.is_file()} == {
-        "pyxis_environment.py"
+        "pyxis_environment.py",
+        "pyxis_worker.py",
     }
 
 
@@ -939,7 +941,7 @@ def test_pyxis_agent_command_uses_host_model_and_image_registry(monkeypatch, tmp
     )
 
     command, kwargs = calls[0]
-    assert command[1:4] == ["-m", "swebench_service.runner", "pyxis-agent"]
+    assert command[1:4] == ["-m", "swebench_service.pyxis_worker", "agent"]
     assert command[command.index("--image-registry") + 1] == _PYXIS_IMAGE_REGISTRY
     assert command[command.index("--filter") + 1] == (
         "^(?:repo__repo\\-1|repo__repo\\-2)$"
@@ -947,16 +949,50 @@ def test_pyxis_agent_command_uses_host_model_and_image_registry(monkeypatch, tmp
     assert kwargs["env"]["OPENAI_API_KEY"] == "model-secret"
 
 
-def test_pyxis_agent_saves_each_live_trajectory_to_its_instance_path(tmp_path):
+def test_pyxis_agent_saves_each_live_trajectory_to_its_instance_path(
+    monkeypatch, tmp_path
+):
     class FakeProgressTrackingAgent:
         def __init__(self, *args, instance_id="", **kwargs):
             self.instance_id = instance_id
             self.kwargs = kwargs
 
-    swebench = types.SimpleNamespace(ProgressTrackingAgent=FakeProgressTrackingAgent)
-    assert hasattr(runner_mod, "_enable_live_trajectory_saves")
+    swebench = types.SimpleNamespace(
+        ProgressTrackingAgent=FakeProgressTrackingAgent,
+        main=lambda **kwargs: None,
+    )
+    minisweagent = types.ModuleType("minisweagent")
+    environments = types.ModuleType("minisweagent.environments")
+    environments.get_environment = lambda config: config
+    run = types.ModuleType("minisweagent.run")
+    benchmarks = types.ModuleType("minisweagent.run.benchmarks")
+    benchmarks.swebench = swebench
+    monkeypatch.setitem(sys.modules, "minisweagent", minisweagent)
+    monkeypatch.setitem(sys.modules, "minisweagent.environments", environments)
+    monkeypatch.setitem(sys.modules, "minisweagent.run", run)
+    monkeypatch.setitem(sys.modules, "minisweagent.run.benchmarks", benchmarks)
 
-    runner_mod._enable_live_trajectory_saves(swebench, tmp_path)
+    worker_mod.main(
+        [
+            "agent",
+            "--model",
+            "test-model",
+            "--config",
+            str(tmp_path / "config.yaml"),
+            "--subset",
+            "verified",
+            "--split",
+            "test",
+            "--filter",
+            "repo__repo-1",
+            "--workers",
+            "1",
+            "--output",
+            str(tmp_path),
+            "--image-registry",
+            _PYXIS_IMAGE_REGISTRY,
+        ]
+    )
     first = swebench.ProgressTrackingAgent(instance_id="repo__repo-1")
     second = swebench.ProgressTrackingAgent(instance_id="repo__repo-2")
 
@@ -995,7 +1031,7 @@ def test_pyxis_eval_command_does_not_forward_model_key(monkeypatch, tmp_path):
     )
 
     command, kwargs = calls[0]
-    assert command[1:4] == ["-m", "swebench_service.runner", "pyxis-eval"]
+    assert command[1:4] == ["-m", "swebench_service.pyxis_worker", "eval"]
     assert command[command.index("--max-workers") + 1] == "2"
     assert command[command.index("--image-registry") + 1] == _PYXIS_IMAGE_REGISTRY
     assert command[command.index("--instance-ids") + 1 :] == ["repo__repo-1"]
@@ -1027,7 +1063,7 @@ def test_pyxis_eval_does_not_mount_report_directory(monkeypatch, tmp_path):
     monkeypatch.setattr(subprocess, "run", fake_run)
     test_spec = types.SimpleNamespace(instance_id="repo__repo-1", eval_script="true")
 
-    _evaluate_pyxis_instance(
+    worker_mod._evaluate_instance(
         test_spec=test_spec,
         prediction={
             "model_name_or_path": "test-model",
@@ -1045,7 +1081,7 @@ def test_pyxis_eval_does_not_mount_report_directory(monkeypatch, tmp_path):
     assert not report.exists()
 
 
-def test_pyxis_result_uses_upstream_report(monkeypatch, tmp_path):
+def test_pyxis_worker_uses_upstream_report(monkeypatch, tmp_path):
     output_dir = tmp_path / "output"
     run_id = "endpoints_test"
     predictions = {
@@ -1073,18 +1109,46 @@ def test_pyxis_result_uses_upstream_report(monkeypatch, tmp_path):
     harness = types.ModuleType("swebench.harness")
     reporting = types.ModuleType("swebench.harness.reporting")
     reporting.make_run_report = fake_make_run_report
+    test_spec = types.ModuleType("swebench.harness.test_spec")
+    test_spec_module = types.ModuleType("swebench.harness.test_spec.test_spec")
+    test_spec_module.make_test_spec = lambda row, arch: row
+    utils = types.ModuleType("swebench.harness.utils")
+    utils.get_predictions_from_file = lambda path, dataset, split: predictions.values()
+    utils.load_swebench_dataset = lambda dataset, split, instance_ids: []
     monkeypatch.setitem(sys.modules, "swebench", swebench)
     monkeypatch.setitem(sys.modules, "swebench.harness", harness)
     monkeypatch.setitem(sys.modules, "swebench.harness.reporting", reporting)
+    monkeypatch.setitem(sys.modules, "swebench.harness.test_spec", test_spec)
+    monkeypatch.setitem(
+        sys.modules, "swebench.harness.test_spec.test_spec", test_spec_module
+    )
+    monkeypatch.setitem(sys.modules, "swebench.harness.utils", utils)
 
-    result_path = _write_pyxis_run_report(
-        output_dir=output_dir,
-        run_id=run_id,
-        instance_ids=["repo__repo-1", "repo__repo-2", "repo__repo-3"],
-        predictions=predictions,
+    worker_mod.main(
+        [
+            "eval",
+            "--dataset-name",
+            "princeton-nlp/SWE-bench_Verified",
+            "--split",
+            "test",
+            "--predictions-path",
+            str(output_dir / "preds.json"),
+            "--max-workers",
+            "1",
+            "--run-id",
+            run_id,
+            "--image-registry",
+            _PYXIS_IMAGE_REGISTRY,
+            "--output-dir",
+            str(output_dir),
+            "--instance-ids",
+            "repo__repo-1",
+            "repo__repo-2",
+            "repo__repo-3",
+        ]
     )
 
-    assert result_path == output_dir / "test-model.endpoints_test.json"
+    assert (output_dir / "test-model.endpoints_test.json").exists()
     assert calls == [
         (
             predictions,

--- a/tests/unit/evaluation/swebench_service/test_runner.py
+++ b/tests/unit/evaluation/swebench_service/test_runner.py
@@ -728,6 +728,25 @@ def test_pyxis_srun_requires_allocation(monkeypatch, tmp_path):
         )
 
 
+def test_pyxis_builds_host_srun_command(monkeypatch):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+
+    command = build_srun_command(argv=["enroot", "list", "-f"])
+
+    assert command == [
+        "srun",
+        "--overlap",
+        "--jobid=1738605",
+        "-N1",
+        "-n1",
+        "--nodelist=gb-nvl-053-compute04",
+        "enroot",
+        "list",
+        "-f",
+    ]
+
+
 def test_pyxis_srun_environment_does_not_forward_credentials(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
     monkeypatch.setenv("SWEBENCH_SERVICE_AUTH_TOKEN", "service-secret")

--- a/tests/unit/evaluation/swebench_service/test_runner.py
+++ b/tests/unit/evaluation/swebench_service/test_runner.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import stat
 import subprocess
 import sys
@@ -12,7 +13,6 @@ from typing import Literal, get_type_hints
 import msgspec.json
 import pytest
 import yaml
-
 from inference_endpoint.evaluation.swebench_service.swebench_service import (
     pyxis_worker as worker_mod,
 )
@@ -835,7 +835,9 @@ def test_pyxis_srun_environment_does_not_forward_credentials(monkeypatch):
     assert "HF_TOKEN" not in environment
 
 
-def test_pyxis_environment_reuses_named_writable_container(monkeypatch, tmp_path):
+def test_pyxis_environment_reuses_named_writable_container(
+    monkeypatch, tmp_path, caplog
+):
     monkeypatch.setenv("SLURM_JOB_ID", "1738605")
     monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
     monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
@@ -857,8 +859,14 @@ def test_pyxis_environment_reuses_named_writable_container(monkeypatch, tmp_path
         timeout=30,
         interpreter=["bash", "-c"],
     )
+    assert environment.config.timeout_s == 30
+    assert environment.serialize()["info"]["config"]["environment"]["timeout"] == 30
 
-    first = environment.execute({"command": "touch state"})
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="inference_endpoint.evaluation.swebench_service.swebench_service.pyxis_environment",
+    ):
+        first = environment.execute({"command": "touch state"})
     second = environment.execute({"command": "test -f state"})
     environment.cleanup()
 
@@ -874,6 +882,9 @@ def test_pyxis_environment_reuses_named_writable_container(monkeypatch, tmp_path
         assert "--no-container-mount-home" in command
         assert kwargs["env"].get("OPENAI_API_KEY") is None
     assert calls[1][0][-5:] == ["env", "PAGER=cat", "bash", "-c", "touch state"]
+    assert any(
+        "unshare --pid --fork --mount-proc" in argument for argument in calls[1][0]
+    )
     assert calls[-1][0][-4:] == [
         "enroot",
         "remove",
@@ -881,6 +892,7 @@ def test_pyxis_environment_reuses_named_writable_container(monkeypatch, tmp_path
         f"pyxis_{container_name}",
     ]
     assert first["returncode"] == second["returncode"] == 0
+    assert "Executing Pyxis command: touch state" in caplog.text
 
 
 def test_pyxis_environment_mounts_persistent_tmp_on_every_step(monkeypatch, tmp_path):
@@ -985,7 +997,7 @@ def test_pyxis_environment_raises_when_srun_never_starts_command(monkeypatch, tm
     environment.config = types.SimpleNamespace(
         cwd="/testbed",
         env={},
-        timeout=30,
+        timeout_s=30,
         interpreter=["bash", "-c"],
         infrastructure_failure_path=failure_path,
     )

--- a/tests/unit/evaluation/swebench_service/test_runner.py
+++ b/tests/unit/evaluation/swebench_service/test_runner.py
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import stat
 import subprocess
 import sys
 import threading
+import types
+from pathlib import Path
 
 import msgspec.json
 import pytest
@@ -11,17 +14,35 @@ import yaml
 from inference_endpoint.evaluation.swebench_service.swebench_service import (
     runner as runner_mod,
 )
+from inference_endpoint.evaluation.swebench_service.swebench_service.pyxis_environment import (
+    PyxisEnvironment,
+    build_srun_command,
+    resolve_image,
+    safe_srun_env,
+)
 from inference_endpoint.evaluation.swebench_service.swebench_service.runner import (
     CancellationToken,
+    PyxisSweBenchRunner,
     RunCancelled,
     RunnerError,
     SweBenchRunner,
+    _evaluate_pyxis_instance,
+    _write_pyxis_run_report,
+    create_runner,
 )
 from inference_endpoint.evaluation.swebench_service.swebench_service.schemas import (
     RunRequest,
 )
 
 pytestmark = pytest.mark.unit
+
+
+def test_pyxis_implementation_adds_only_environment_module():
+    package_dir = Path(runner_mod.__file__).parent
+
+    assert {path.name for path in package_dir.glob("pyxis_*") if path.is_file()} == {
+        "pyxis_environment.py"
+    }
 
 
 def _request(endpoints: list[str]) -> RunRequest:
@@ -189,6 +210,26 @@ def test_patch_config_normalizes_api_base(tmp_path, endpoint, expected_api_base)
     assert "model_class" not in cfg["model"]
     assert "api_key" not in cfg["model"]["model_kwargs"]
     assert cfg["environment"]["run_args"] == [
+        "--rm",
+        "--label",
+        "com.mlcommons.endpoints.swebench-run=run-123",
+    ]
+
+
+def test_patch_config_uses_requested_docker_runtime(monkeypatch, tmp_path):
+    monkeypatch.setenv("SWEBENCH_DOCKER_RUNTIME", "runc")
+    runner = SweBenchRunner(project_root=tmp_path, subprocess_timeout_s=30)
+
+    patched = runner._patch_config(
+        tmp_path,
+        _request(["http://localhost:30000"]),
+        run_id="run-123",
+    )
+
+    cfg = yaml.safe_load(patched.read_text())
+    assert cfg["environment"]["run_args"] == [
+        "--runtime",
+        "runc",
         "--rm",
         "--label",
         "com.mlcommons.endpoints.swebench-run=run-123",
@@ -558,4 +599,482 @@ def test_cleanup_exactly_matches_harness_container_names(monkeypatch, tmp_path):
             "{{.ID}}\t{{.Names}}",
         ],
         ["docker", "rm", "-f", "agent-container", "eval-container"],
+    ]
+
+
+def _pyxis_request(instance_ids: list[str] | None = None) -> RunRequest:
+    instance_ids = instance_ids or ["repo__repo-1"]
+    return RunRequest(
+        model_name="test-model",
+        endpoint_urls=["http://endpoint:30000"],
+        generation_params={"temperature": 0.2},
+        subset="lite",
+        split="test",
+        num_instances=len(instance_ids),
+        workers=2,
+        max_eval_workers=2,
+        evaluated_instance_ids=instance_ids,
+    )
+
+
+_PYXIS_IMAGE_REGISTRY = "gitlab-master.nvidia.com:5005/hvagadia/swebench-arm64-images"
+
+
+def test_create_runner_defaults_to_docker(tmp_path):
+    runner = create_runner(
+        "docker",
+        project_root=tmp_path,
+        subprocess_timeout_s=30,
+        image_registry=None,
+    )
+
+    assert type(runner) is SweBenchRunner
+
+
+def test_create_runner_requires_image_registry_for_pyxis(tmp_path):
+    with pytest.raises(ValueError, match="image registry"):
+        create_runner(
+            "pyxis",
+            project_root=tmp_path,
+            subprocess_timeout_s=30,
+            image_registry=None,
+        )
+
+
+def test_create_runner_selects_pyxis(tmp_path):
+    runner = create_runner(
+        "pyxis",
+        project_root=tmp_path,
+        subprocess_timeout_s=30,
+        image_registry=_PYXIS_IMAGE_REGISTRY,
+    )
+
+    assert isinstance(runner, PyxisSweBenchRunner)
+
+
+def test_pyxis_patch_config_selects_pyxis_environment(tmp_path):
+    runner = PyxisSweBenchRunner(
+        project_root=tmp_path,
+        subprocess_timeout_s=30,
+        image_registry=_PYXIS_IMAGE_REGISTRY,
+    )
+
+    patched = runner._patch_config(tmp_path, _pyxis_request(), run_id="run-1")
+
+    environment = yaml.safe_load(patched.read_text())["environment"]
+    assert environment["environment_class"] == (
+        "swebench_service.pyxis_environment.PyxisEnvironment"
+    )
+    assert environment["cwd"] == "/testbed"
+    assert environment["run_id"] == "run-1"
+    assert "run_args" not in environment
+    assert "pull_timeout" not in environment
+    assert "container_timeout" not in environment
+
+
+def test_pyxis_resolves_registry_image_from_instance_id():
+    assert resolve_image(_PYXIS_IMAGE_REGISTRY, "repo__repo-1") == (
+        "gitlab-master.nvidia.com:5005#hvagadia/swebench-arm64-images/"
+        "sweb.eval.arm64.repo__repo-1:v4.1.0-arm64"
+    )
+    with pytest.raises(RunnerError, match="invalid SWE-bench instance ID"):
+        resolve_image(_PYXIS_IMAGE_REGISTRY, "../repo__repo-1")
+
+
+def test_pyxis_builds_one_node_srun_command(monkeypatch, tmp_path):
+    image = resolve_image(_PYXIS_IMAGE_REGISTRY, "repo__repo-1")
+    source = tmp_path / "input.json"
+    source.touch()
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+
+    command = build_srun_command(
+        image=image,
+        name="minisweagent-run-1",
+        mounts=[(source, "/swebench/input.json")],
+        workdir="/testbed",
+        argv=["python", "worker.py"],
+    )
+
+    assert command == [
+        "srun",
+        "--overlap",
+        "--jobid=1738605",
+        "-N1",
+        "-n1",
+        "--nodelist=gb-nvl-053-compute04",
+        f"--container-image={image}",
+        "--container-name=minisweagent-run-1",
+        "--container-writable",
+        "--container-remap-root",
+        "--no-container-mount-home",
+        f"--container-mounts={source.resolve()}:/swebench/input.json",
+        "--container-workdir=/testbed",
+        "python",
+        "worker.py",
+    ]
+
+
+def test_pyxis_srun_requires_allocation(monkeypatch, tmp_path):
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+
+    with pytest.raises(RunnerError, match="SLURM_JOB_ID"):
+        build_srun_command(
+            image=resolve_image(_PYXIS_IMAGE_REGISTRY, "repo__repo-1"),
+            name=None,
+            mounts=[],
+            workdir="/testbed",
+            argv=["true"],
+        )
+
+
+def test_pyxis_srun_environment_does_not_forward_credentials(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
+    monkeypatch.setenv("SWEBENCH_SERVICE_AUTH_TOKEN", "service-secret")
+    monkeypatch.setenv("HF_TOKEN", "dataset-secret")
+
+    environment = safe_srun_env()
+
+    assert "OPENAI_API_KEY" not in environment
+    assert "SWEBENCH_SERVICE_AUTH_TOKEN" not in environment
+    assert "HF_TOKEN" not in environment
+
+
+def test_pyxis_environment_reuses_named_writable_container(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+    monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
+    image = tmp_path / "task.sqsh"
+    image.touch()
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    environment = PyxisEnvironment(
+        image=image,
+        run_id="run-1",
+        cwd="/testbed",
+        env={"PAGER": "cat"},
+        timeout=30,
+        interpreter=["bash", "-c"],
+    )
+
+    first = environment.execute({"command": "touch state"})
+    second = environment.execute({"command": "test -f state"})
+    environment.cleanup()
+
+    container_name = next(
+        argument.split("=", 1)[1]
+        for argument in calls[0][0]
+        if argument.startswith("--container-name=")
+    )
+    assert f"--container-image={image.resolve()}" in calls[0][0]
+    for command, kwargs in calls[1:3]:
+        assert f"--container-name={container_name}" in command
+        assert not any(arg.startswith("--container-image=") for arg in command)
+        assert "--no-container-mount-home" in command
+        assert kwargs["env"].get("OPENAI_API_KEY") is None
+    assert calls[1][0][-5:] == ["env", "PAGER=cat", "bash", "-c", "touch state"]
+    assert calls[-1][0][-4:] == [
+        "enroot",
+        "remove",
+        "-f",
+        f"pyxis_{container_name}",
+    ]
+    assert first["returncode"] == second["returncode"] == 0
+
+
+def test_pyxis_environment_mounts_persistent_tmp_on_every_step(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+    image = tmp_path / "task.sqsh"
+    image.touch()
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    environment = PyxisEnvironment(image=image, run_id="run-1")
+    environment.execute({"command": "touch /tmp/state"})
+    environment.execute({"command": "test -f /tmp/state"})
+
+    tmp_mounts = [
+        next(arg for arg in command if arg.startswith("--container-mounts="))
+        for command in calls[:3]
+    ]
+    assert tmp_mounts[0] == tmp_mounts[1] == tmp_mounts[2]
+    source, destination = (
+        tmp_mounts[0].removeprefix("--container-mounts=").split(":", 1)
+    )
+    assert destination == "/tmp"
+    persistent_tmp = Path(source)
+    assert persistent_tmp.is_dir()
+    assert stat.S_IMODE(persistent_tmp.stat().st_mode) == 0o1777
+
+    environment.cleanup()
+
+    assert not persistent_tmp.exists()
+
+
+def test_pyxis_cleanup_is_best_effort_outside_allocation(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, stdout=""),
+    )
+    image = tmp_path / "task.sqsh"
+    image.touch()
+    environment = PyxisEnvironment(image=image, run_id="run-1")
+    persistent_tmp = environment._tmp_dir
+    monkeypatch.delenv("SLURM_JOB_ID")
+
+    environment.cleanup()
+
+    assert not persistent_tmp.exists()
+
+
+def test_pyxis_start_failure_removes_persistent_tmp(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    image = tmp_path / "task.sqsh"
+    image.touch()
+    persistent_tmp: Path | None = None
+
+    def fake_run(command, **kwargs):
+        nonlocal persistent_tmp
+        if any(arg.startswith("--container-image=") for arg in command):
+            mount = next(
+                arg for arg in command if arg.startswith("--container-mounts=")
+            )
+            source = mount.removeprefix("--container-mounts=").split(":", 1)[0]
+            persistent_tmp = Path(source)
+            raise subprocess.CalledProcessError(1, command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RunnerError, match="failed to start Pyxis container"):
+        PyxisEnvironment(image=image, run_id="run-1")
+
+    assert persistent_tmp is not None
+    assert not persistent_tmp.exists()
+
+
+def test_pyxis_cleanup_removes_only_exact_run_prefix(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    monkeypatch.setenv("SLURMD_NODENAME", "gb-nvl-053-compute04")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        output = ""
+        if command[-3:] == ["enroot", "list", "-f"]:
+            output = (
+                "NAME PID COMM STATE STARTED TIME MNTNS USERNS COMMAND\n"
+                "pyxis_mswe_run-1_abcd1234                         \n"
+                "pyxis_mswe_run-10_ffff0000                        \n"
+                "unrelated                                         \n"
+            )
+        return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = PyxisSweBenchRunner(
+        project_root=tmp_path,
+        subprocess_timeout_s=30,
+        image_registry=_PYXIS_IMAGE_REGISTRY,
+    )
+
+    runner._cleanup_containers("run-1")
+
+    assert [command[-4:] for command in calls[1:]] == [
+        ["enroot", "remove", "-f", "pyxis_mswe_run-1_abcd1234"]
+    ]
+
+
+def test_pyxis_agent_command_uses_host_model_and_image_registry(monkeypatch, tmp_path):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(command, log_path, **kwargs):
+        calls.append((command, kwargs))
+
+    monkeypatch.setattr(runner_mod, "_run_subprocess", fake_run)
+    request = _pyxis_request(["repo__repo-1", "repo__repo-2"])
+    request.endpoint_api_key = "model-secret"
+    runner = PyxisSweBenchRunner(
+        project_root=tmp_path,
+        subprocess_timeout_s=30,
+        image_registry=_PYXIS_IMAGE_REGISTRY,
+    )
+
+    runner._run_agent(
+        request,
+        tmp_path / "config.yaml",
+        tmp_path,
+        tmp_path,
+        {"model-secret"},
+    )
+
+    command, kwargs = calls[0]
+    assert command[1:4] == ["-m", "swebench_service.runner", "pyxis-agent"]
+    assert command[command.index("--image-registry") + 1] == _PYXIS_IMAGE_REGISTRY
+    assert command[command.index("--filter") + 1] == (
+        "^(?:repo__repo\\-1|repo__repo\\-2)$"
+    )
+    assert kwargs["env"]["OPENAI_API_KEY"] == "model-secret"
+
+
+def test_pyxis_agent_saves_each_live_trajectory_to_its_instance_path(tmp_path):
+    class FakeProgressTrackingAgent:
+        def __init__(self, *args, instance_id="", **kwargs):
+            self.instance_id = instance_id
+            self.kwargs = kwargs
+
+    swebench = types.SimpleNamespace(ProgressTrackingAgent=FakeProgressTrackingAgent)
+    assert hasattr(runner_mod, "_enable_live_trajectory_saves")
+
+    runner_mod._enable_live_trajectory_saves(swebench, tmp_path)
+    first = swebench.ProgressTrackingAgent(instance_id="repo__repo-1")
+    second = swebench.ProgressTrackingAgent(instance_id="repo__repo-2")
+
+    assert first.kwargs["output_path"] == (
+        tmp_path / "repo__repo-1" / "repo__repo-1.live.json"
+    )
+    assert second.kwargs["output_path"] == (
+        tmp_path / "repo__repo-2" / "repo__repo-2.live.json"
+    )
+
+
+def test_pyxis_eval_command_does_not_forward_model_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-secret")
+    calls: list[tuple[list[str], dict]] = []
+    output_dir = tmp_path / "output"
+    run_dir = tmp_path / "run"
+    output_dir.mkdir()
+    run_dir.mkdir()
+    preds_path = output_dir / "preds.json"
+    preds_path.write_text("{}")
+
+    def fake_run(command, log_path, *, cwd, env, **kwargs):
+        calls.append((command, {"cwd": cwd, "env": env}))
+        run_id = command[command.index("--run-id") + 1]
+        (cwd / f"test-model.{run_id}.json").write_text("{}")
+
+    monkeypatch.setattr(runner_mod, "_run_subprocess", fake_run)
+    runner = PyxisSweBenchRunner(
+        project_root=tmp_path,
+        subprocess_timeout_s=30,
+        image_registry=_PYXIS_IMAGE_REGISTRY,
+    )
+
+    result = runner._run_eval(
+        _pyxis_request(), preds_path, output_dir, run_dir, {"ambient-secret"}
+    )
+
+    command, kwargs = calls[0]
+    assert command[1:4] == ["-m", "swebench_service.runner", "pyxis-eval"]
+    assert command[command.index("--max-workers") + 1] == "2"
+    assert command[command.index("--image-registry") + 1] == _PYXIS_IMAGE_REGISTRY
+    assert command[command.index("--instance-ids") + 1 :] == ["repo__repo-1"]
+    assert "OPENAI_API_KEY" not in kwargs["env"]
+    assert result.exists()
+
+
+def test_pyxis_eval_does_not_mount_report_directory(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLURM_JOB_ID", "1738605")
+    image = tmp_path / "task.sqsh"
+    image.touch()
+    report = (
+        tmp_path
+        / "logs"
+        / "run_evaluation"
+        / "run-1"
+        / "test-model"
+        / "repo__repo-1"
+        / "report.json"
+    )
+    report.parent.mkdir(parents=True)
+    report.write_text('{"repo__repo-1":{"resolved":true}}')
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="failed")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    test_spec = types.SimpleNamespace(instance_id="repo__repo-1", eval_script="true")
+
+    _evaluate_pyxis_instance(
+        test_spec=test_spec,
+        prediction={
+            "model_name_or_path": "test-model",
+            "model_patch": "diff --git a/a b/a",
+        },
+        image=image,
+        output_dir=tmp_path,
+        run_id="run-1",
+        timeout_s=30,
+    )
+
+    mounts = next(arg for arg in calls[0] if arg.startswith("--container-mounts="))
+    assert "report.json" not in mounts
+    assert f"{report.parent.resolve()}:/" not in mounts
+    assert not report.exists()
+
+
+def test_pyxis_result_uses_upstream_report(monkeypatch, tmp_path):
+    output_dir = tmp_path / "output"
+    run_id = "endpoints_test"
+    predictions = {
+        "repo__repo-1": {
+            "model_name_or_path": "test-model",
+            "instance_id": "repo__repo-1",
+            "model_patch": "diff --git a/a b/a",
+        },
+        "repo__repo-2": {
+            "model_name_or_path": "test-model",
+            "instance_id": "repo__repo-2",
+            "model_patch": "",
+        },
+    }
+    output_dir.mkdir()
+    calls = []
+
+    def fake_make_run_report(predictions, dataset, run_id, client):
+        calls.append((predictions, dataset, run_id, client))
+        result = tmp_path / "output" / "test-model.endpoints_test.json"
+        result.write_text("{}")
+        return result.name
+
+    swebench = types.ModuleType("swebench")
+    harness = types.ModuleType("swebench.harness")
+    reporting = types.ModuleType("swebench.harness.reporting")
+    reporting.make_run_report = fake_make_run_report
+    monkeypatch.setitem(sys.modules, "swebench", swebench)
+    monkeypatch.setitem(sys.modules, "swebench.harness", harness)
+    monkeypatch.setitem(sys.modules, "swebench.harness.reporting", reporting)
+
+    result_path = _write_pyxis_run_report(
+        output_dir=output_dir,
+        run_id=run_id,
+        instance_ids=["repo__repo-1", "repo__repo-2", "repo__repo-3"],
+        predictions=predictions,
+    )
+
+    assert result_path == output_dir / "test-model.endpoints_test.json"
+    assert calls == [
+        (
+            predictions,
+            [
+                {"instance_id": "repo__repo-1"},
+                {"instance_id": "repo__repo-2"},
+                {"instance_id": "repo__repo-3"},
+            ],
+            run_id,
+            None,
+        )
     ]


### PR DESCRIPTION
## Summary

- add an optional Pyxis runtime to the SWE-bench accuracy service
- run mini-swe-agent tool commands and SWE-bench evaluation through `srun` and Enroot on a retained one-node Slurm allocation
- resolve task images from a registry prefix using the documented `sweb.eval.arm64.<instance_id>:v4.1.0-arm64` convention
- preserve Docker as the default runtime and leave the benchmark client configuration unchanged

## Why

ARM64 Slurm nodes provide Pyxis and Enroot but may not provide Docker. This allows the existing external SWE-bench accuracy service to run agent and evaluator containers natively on those nodes without changing its HTTP API or the endpoint client YAML.

## Validation

- `uv run pytest -q tests/unit/evaluation/swebench_service` — 72 passed
- targeted `pre-commit` checks for all five changed files — passed
