### PR TITLE
feat(metrics): report input sequence lengths

### DIFF
--- a/docs/async_utils/services/metrics_aggregator/DESIGN.md
+++ b/docs/async_utils/services/metrics_aggregator/DESIGN.md
@@ -26,9 +26,11 @@ partial snapshot tagged `INTERRUPTED`.
 
 ## Token metrics pipeline
 
-ISL/OSL/TPOT require tokenizer passes per completed sample; at high completion
-rates a per-event dispatch model accumulates an unbounded backlog. The
-pipeline batches instead: **defer-to-flush** + **process-sharded encoding**.
+ISL/OSL/TPOT may require tokenizer passes: ISL is emitted at `ISSUED` from
+pre-tokenized input IDs or raw prompt text, while OSL and TPOT are emitted from
+completion data. At high event rates a per-event dispatch model accumulates an
+unbounded backlog. The pipeline batches instead: **defer-to-flush** +
+**process-sharded encoding**.
 
 ### Defer-to-flush (`TokenBatchQueue`)
 

--- a/docs/metrics/report_design.md
+++ b/docs/metrics/report_design.md
@@ -22,7 +22,7 @@ final_snapshot.json  (dict form of MetricsSnapshot)
         ├── counters  → n_samples_issued/completed/failed, tracked_duration_ns,
         │                legacy_loadgen_window_duration_ns, finish-reason counts
         │
-        ├── for each series (ttft, tpot, latency, osl):
+        ├── for each series (ttft, tpot, latency, isl, osl):
         │       _series_to_metric_dict(stat) → rollup dict
         │
         └── derive qps / tps once (window chosen by run config)
@@ -67,8 +67,9 @@ p50. A zero-count series returns `{}` (or an all-null early-stopping map if the 
 ### `Report` (frozen `msgspec.Struct`)
 
 Fields: `version`, `git_sha`, `test_started_at`, `n_samples_issued/completed/failed`,
-`duration_ns`, `state`, `complete`, the four rollup dicts (`ttft`, `tpot`, `latency`,
-`output_sequence_lengths`), `legacy_loadgen_window_duration_ns`, `qps`, `tps`,
+`duration_ns`, `state`, `complete`, the five rollup dicts (`ttft`, `tpot`, `latency`,
+`input_sequence_lengths`, `output_sequence_lengths`), `legacy_loadgen_window_duration_ns`,
+`qps`, `tps`,
 `finish_reason_counts`, `run_config`, and `accuracy`.
 
 - `complete` = `state == "complete" and n_pending_tasks == 0` — `False` marks partial async metrics
@@ -88,7 +89,15 @@ Counter keys read: `tracked_samples_issued`, `tracked_samples_completed`,
 `tracked_samples_failed`, `tracked_duration_ns`, `legacy_loadgen_window_duration_ns`, and the
 `tracked_finish_reason_*` counters. Series read (snapshot key → report field, via
 `SERIES_TO_SUMMARY_FIELD`): `ttft_ns` → `ttft`, `tpot_ns` → `tpot`, `sample_latency_ns` →
-`latency`, and `osl` → `output_sequence_lengths`.
+`latency`. The token-length series are mapped directly: `isl` → `input_sequence_lengths` and
+`osl` → `output_sequence_lengths`. Both report fields use the same full distribution shape:
+`total`, `min`, `max`, `median`, `avg`, `std_dev`, `percentiles`, and `histogram`.
+
+**Input sequence length (ISL).** The metrics aggregator records ISL at `ISSUED`, using
+`len(token_ids)` when a dataset provides pre-tokenized input and otherwise tokenizing the raw
+text prompt with the configured reference tokenizer. This records the workload's intended input
+distribution as early as possible. `input_sequence_lengths` is empty when no ISL values were
+recorded (for example, no tokenizer is available for text-only inputs).
 
 **QPS/TPS window selection.** The snapshot always carries both a native window
 (`tracked_duration_ns`) and the MLPerf LoadGen "completed" window

--- a/examples/11_Edge_Agentic_Example/online_edge_full_run.yaml
+++ b/examples/11_Edge_Agentic_Example/online_edge_full_run.yaml
@@ -39,7 +39,8 @@ model_params:
   name: "Qwen3.6-27B-Q4_K_M" # set to your served model name.
   # HF tokenizer for client-side token metrics (ISL / OSL / TPOT). Without it
   # the served GGUF name above is not a loadable tokenizer, so the metrics
-  # aggregator cannot count output tokens and the OSL / TPOT blocks in
+  # aggregator cannot count text-based input or output tokens, and the ISL /
+  # OSL / TPOT blocks in
   # result_summary.json are left empty. Point this at the model's canonical
   # HF tokenizer (or a local path).
   tokenizer_name: "Qwen/Qwen3.6-27B"

--- a/src/inference_endpoint/async_utils/services/metrics_aggregator/registry.py
+++ b/src/inference_endpoint/async_utils/services/metrics_aggregator/registry.py
@@ -423,13 +423,12 @@ class MetricsRegistry:
 
     # -- registration -----------------------------------------------------
 
-    def register_counter(self, name: str, dtype: type = int) -> CounterSampler:
+    def register_counter(self, name: str, dtype: type = int) -> None:
         if name in self._seen_names:
             raise ValueError(f"Metric name already registered: {name}")
         sampler = CounterSampler(name, dtype=dtype)
         self._counters[name] = sampler
         self._seen_names.add(name)
-        return sampler
 
     def register_series(
         self,
@@ -442,7 +441,7 @@ class MetricsRegistry:
         percentiles: tuple[float, ...] = DEFAULT_PERCENTILES,
         dtype: type = int,
         tail_latency: bool = False,
-    ) -> SeriesSampler:
+    ) -> None:
         """Register a new series.
 
         ``percentiles`` MUST include ``50.0`` (or ``50``) — median is a
@@ -474,7 +473,6 @@ class MetricsRegistry:
         )
         self._series[name] = sampler
         self._seen_names.add(name)
-        return sampler
 
     # -- hot path ---------------------------------------------------------
     # Direct dict lookup, no isinstance dispatch — these are called once per

--- a/src/inference_endpoint/metrics/report.py
+++ b/src/inference_endpoint/metrics/report.py
@@ -202,6 +202,7 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
     tpot: dict[str, Any]
     latency: dict[str, Any]
     output_sequence_lengths: dict[str, Any]
+    input_sequence_lengths: dict[str, Any]
     # Legacy MLPerf LoadGen Server "completed" window (poisson only): first
     # issued request -> completion of the last-issued request
     # (final_query_all_samples_done_time analog; see mlcommons/inference
@@ -297,6 +298,7 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
         raw_duration_ns = _counter("tracked_duration_ns")
         duration_ns = raw_duration_ns if raw_duration_ns > 0 else None
         n_completed = _counter("tracked_samples_completed")
+        isl = _series_dict("isl")
         osl = _series_dict("osl")
 
         # Legacy MLPerf LoadGen Server "completed" window (poisson only): first
@@ -361,6 +363,7 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
                 field: _series_dict(series)
                 for series, field in SERIES_TO_SUMMARY_FIELD.items()
             },
+            input_sequence_lengths=isl,
             output_sequence_lengths=osl,
             legacy_loadgen_window_duration_ns=legacy_loadgen_window_duration_ns,
             qps=qps,
@@ -495,6 +498,7 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
             ("TTFT", self.ttft, "ms", 1e-6),
             ("TPOT", self.tpot, "ms", 1e-6),
             ("Latency", self.latency, "ms", 1e-6),
+            ("Input sequence lengths", self.input_sequence_lengths, "tokens", 1.0),
             ("Output sequence lengths", self.output_sequence_lengths, "tokens", 1.0),
         ]:
             if not metric_dict:

--- a/tests/unit/metrics/test_report_builder.py
+++ b/tests/unit/metrics/test_report_builder.py
@@ -97,10 +97,10 @@ def _make_registry(n_samples: int = 50) -> MetricsRegistry:
     """A registry populated with the metrics ``Report.from_snapshot`` reads.
 
     Only the metrics consumed by ``Report.from_snapshot`` are registered:
-    the tracked counters (issued/completed/failed/duration) and the four
-    series surfaced on the report (ttft_ns, sample_latency_ns, osl,
-    tpot_ns). ISL/chunk_delta_ns are intentionally not registered to
-    keep the test data minimal — ``Report.from_snapshot`` ignores them.
+    the tracked counters (issued/completed/failed/duration) and the five
+    series surfaced on the report (ttft_ns, sample_latency_ns, isl, osl,
+    tpot_ns). ``chunk_delta_ns`` is intentionally not registered to keep the
+    test data minimal — ``Report.from_snapshot`` ignores it.
     """
     registry = MetricsRegistry()
     for key in MetricCounterKey.__members__.values():
@@ -117,6 +117,14 @@ def _make_registry(n_samples: int = 50) -> MetricsRegistry:
         MetricSeriesKey.TTFT_NS.value,
         hdr_low=1,
         hdr_high=_NS_HIGH,
+        sig_figs=3,
+        n_histogram_buckets=10,
+        percentiles=(50.0, 90.0, 99.0),
+    )
+    registry.register_series(
+        MetricSeriesKey.ISL.value,
+        hdr_low=1,
+        hdr_high=10_000_000,
         sig_figs=3,
         n_histogram_buckets=10,
         percentiles=(50.0, 90.0, 99.0),
@@ -148,6 +156,7 @@ def _make_registry(n_samples: int = 50) -> MetricsRegistry:
             registry.record(
                 MetricSeriesKey.SAMPLE_LATENCY_NS.value, 5_000_000 + i * 50_000
             )
+            registry.record(MetricSeriesKey.ISL.value, 50 + i)
             registry.record(MetricSeriesKey.OSL.value, 100 + i)
 
     return registry
@@ -203,6 +212,7 @@ class TestFromSnapshot:
         # Series with count==0 should produce empty dicts.
         assert report.ttft == {}
         assert report.latency == {}
+        assert report.input_sequence_lengths == {}
         assert report.output_sequence_lengths == {}
         assert report.tpot == {}
 
@@ -222,6 +232,30 @@ class TestFromSnapshot:
         assert "histogram" in report.ttft
         assert report.ttft["min"] > 0
         assert report.latency["min"] > 0
+        isl = report.input_sequence_lengths
+        osl = report.output_sequence_lengths
+        # The fixture records distinct ranges (ISL: 50..99; OSL: 100..149).
+        # Assert the full scalar rollups so this fails if the report accidentally
+        # maps the OSL snapshot series into input_sequence_lengths.
+        assert isl["total"] == sum(range(50, 100))
+        assert isl["min"] == 50
+        assert isl["max"] == 99
+        assert isl["median"] == 74.0
+        assert isl["avg"] == 74.5
+        assert isl["std_dev"] == pytest.approx(math.sqrt(212.5))
+        assert osl["total"] == sum(range(100, 150))
+        assert osl["min"] == 100
+        assert osl["max"] == 149
+        assert osl["median"] == 124.0
+        assert osl["avg"] == 124.5
+        assert osl["std_dev"] == pytest.approx(math.sqrt(212.5))
+        # Both series retain the same schema, but preserve their own percentile
+        # values and histogram bucket edges from the snapshot.
+        assert set(isl) == set(osl)
+        assert isl["percentiles"] != osl["percentiles"]
+        assert isl["histogram"]["buckets"] != osl["histogram"]["buckets"]
+        assert sum(isl["histogram"]["counts"]) == 50
+        assert sum(osl["histogram"]["counts"]) == 50
         # No TPOT recordings in the registry → empty dict.
         assert report.tpot == {}
         # OSL data was written → tps is computable.
@@ -473,6 +507,7 @@ class TestReportDisplayAndSerialize:
             ttft={},
             tpot={},
             latency={},
+            input_sequence_lengths={},
             output_sequence_lengths={},
         )
         lines: list[str] = []
@@ -495,6 +530,7 @@ class TestReportDisplayAndSerialize:
             ttft={},
             tpot={},
             latency={},
+            input_sequence_lengths={},
             output_sequence_lengths={},
         )
         lines: list[str] = []
@@ -517,6 +553,7 @@ class TestReportDisplayAndSerialize:
             ttft={},
             tpot={},
             latency={},
+            input_sequence_lengths={},
             output_sequence_lengths={},
         )
         lines: list[str] = []


### PR DESCRIPTION
 ## Summary

  Add `input_sequence_lengths` to the performance `result_summary.json`.

  This exposes the existing ISL metric using the same full distribution
  format as `output_sequence_lengths`:

  - total, min, max, median, average, standard deviation
  - percentile grid


 ## What does this PR do?

  Related to https://github.com/mlcommons/endpoints/issues/439.

  Expose the existing ISL metric as `input_sequence_lengths` in the
  performance
  `result_summary.json`, using the same full distribution format as
  `output_sequence_lengths`:

  - total, min, max, median, average, and standard deviation
  - percentiles
  - histogram buckets and counts

  Also render input sequence lengths in the terminal report.

  ## Type of change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Documentation update
  - [ ] Refactor/cleanup

  ## Related issues

  Closes #439

  ## Testing

  - [x] Tests added/updated
  - [x] All tests pass locally
    - `uv run pytest tests/unit/metrics/test_report_builder.py tests/unit/
    async_utils/services/metrics_aggregator/test_registry.py`
    - 73 passed
  - [x] Manual testing completed

  ## Checklist

  - [x] Code follows project style
  - [x] Pre-commit hooks pass
    - Note: repo-wide mypy has 3 unrelated macOS errors for
      `os.sched_setaffinity` / `os.sched_getaffinity`.
  - [x] Documentation updated (if needed)