### PR TITLE
Make agentic routing headers configurable

### DIFF
--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -572,6 +572,16 @@ def _build_phases(
     drain_cfg = ctx.config.settings.drain
 
     if ctx.dataloader is not None and ctx.rt_settings is not None:
+        perf_dataset = next(
+            dataset
+            for dataset in ctx.config.datasets
+            if dataset.type == DatasetType.PERFORMANCE
+        )
+        routing_headers = (
+            perf_dataset.agentic_inference.routing_headers
+            if perf_dataset.agentic_inference is not None
+            else ()
+        )
         warmup_cfg = ctx.config.settings.warmup
         if warmup_cfg.enabled:
             warmup_dataset: Dataset = (
@@ -611,6 +621,7 @@ def _build_phases(
                 PhaseType.PERFORMANCE,
                 strategy=perf_strategy,
                 drain_timeout=drain_cfg.performance_timeout_s,
+                routing_headers=routing_headers,
             )
         )
 

--- a/src/inference_endpoint/config/schema.py
+++ b/src/inference_endpoint/config/schema.py
@@ -416,6 +416,13 @@ class AgenticInferenceConfig(BaseModel):
             "in dataset."
         ),
     )
+    routing_headers: tuple[str, ...] = Field(
+        default=("X-Session-ID",),
+        description=(
+            "HTTP header names populated with the conversation ID on every "
+            "agentic request."
+        ),
+    )
     num_trajectories_to_issue: int | None = Field(
         default=None,
         gt=0,

--- a/src/inference_endpoint/load_generator/session.py
+++ b/src/inference_endpoint/load_generator/session.py
@@ -172,8 +172,8 @@ class PhaseIssuer:
         issuer: SampleIssuer,
         publisher: EventPublisher,
         stop_check: Callable[[], bool],
-        routing_headers: tuple[str, ...],
         on_inflight_drained: Callable[[], None] | None = None,
+        routing_headers: tuple[str, ...] = (),
     ):
         self._dataset = dataset
         self._issuer = issuer

--- a/src/inference_endpoint/load_generator/session.py
+++ b/src/inference_endpoint/load_generator/session.py
@@ -46,7 +46,6 @@ from .strategy import LoadStrategy, create_load_strategy
 
 logger = logging.getLogger(__name__)
 
-_SESSION_ID_HEADER = "X-Session-ID"
 # ---------------------------------------------------------------------------
 # Phase configuration
 # ---------------------------------------------------------------------------
@@ -71,6 +70,7 @@ class PhaseConfig:
     drain_after: bool = True
     drain_timeout: float | None = None
     strategy: LoadStrategy | None = field(default=None, compare=False)
+    routing_headers: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -157,6 +157,7 @@ class PhaseIssuer:
         "_performance_tracking_stopped",
         "_prompt_warning_reasons",
         "_publisher",
+        "_routing_headers",
         "_stop_check",
         "uuid_to_index",
         "uuid_to_conv_info",
@@ -171,6 +172,7 @@ class PhaseIssuer:
         issuer: SampleIssuer,
         publisher: EventPublisher,
         stop_check: Callable[[], bool],
+        routing_headers: tuple[str, ...],
         on_inflight_drained: Callable[[], None] | None = None,
     ):
         self._dataset = dataset
@@ -178,6 +180,7 @@ class PhaseIssuer:
         self._publisher = publisher
         self._stop_check = stop_check
         self._on_inflight_drained = on_inflight_drained or (lambda: None)
+        self._routing_headers = routing_headers
         self.uuid_to_index: dict[str, int] = {}
         self.uuid_to_conv_info: dict[str, tuple[str, int | None]] = {}
         self.completed_uuids: set[str] = set()
@@ -238,7 +241,11 @@ class PhaseIssuer:
         data = self._dataset.load_sample(sample_index)
         if data_override is not None:
             data = {**data, **data_override}
-        headers = {_SESSION_ID_HEADER: conversation_id} if conversation_id else {}
+        headers = (
+            dict.fromkeys(self._routing_headers, conversation_id)
+            if conversation_id
+            else {}
+        )
         query = Query(id=query_id, data=data, headers=headers)
         self.uuid_to_index[query_id] = sample_index
         self.uuid_to_conv_info[query_id] = (conversation_id, turn)
@@ -471,6 +478,7 @@ class BenchmarkSession:
             publisher=self._publisher,
             stop_check=self._make_stop_check(phase.runtime_settings, phase_start),
             on_inflight_drained=self._drain_event.set,
+            routing_headers=phase.routing_headers,
         )
 
         self._current_phase_issuer = phase_issuer

--- a/tests/unit/commands/test_benchmark.py
+++ b/tests/unit/commands/test_benchmark.py
@@ -57,6 +57,7 @@ from inference_endpoint.commands.benchmark.profiling import (
 )
 from inference_endpoint.config.runtime_settings import RuntimeSettings
 from inference_endpoint.config.schema import (
+    AgenticInferenceConfig,
     BenchmarkConfig,
     DatasetType,
     DrainConfig,
@@ -71,6 +72,9 @@ from inference_endpoint.config.schema import (
     TestMode,
     TestType,
     WarmupConfig,
+)
+from inference_endpoint.config.schema import (
+    Dataset as DatasetConfig,
 )
 from inference_endpoint.config.schema import (
     OfflineBenchmarkConfig as OfflineConfig,
@@ -1661,6 +1665,36 @@ class TestBuildPhases:
 
         assert len(phases) == 1
         assert phases[0].phase_type == PhaseType.PERFORMANCE
+
+    @pytest.mark.unit
+    def test_agentic_routing_headers_propagate_to_performance_phase(
+        self, base_rt_settings, simple_dataset
+    ):
+        routing_headers = ["X-Session-ID", "X-SMG-Routing-Key"]
+        config = OnlineConfig(
+            **_OFFLINE_KWARGS
+            | {
+                "datasets": [
+                    DatasetConfig(
+                        path="agentic.jsonl",
+                        agentic_inference=AgenticInferenceConfig(
+                            routing_headers=routing_headers
+                        ),
+                    )
+                ],
+                "settings": OnlineSettings(
+                    load_pattern=LoadPattern(
+                        type=LoadPatternType.AGENTIC_INFERENCE,
+                        target_concurrency=8,
+                    )
+                ),
+            }
+        )
+        ctx = self._make_ctx(config, base_rt_settings, simple_dataset)
+
+        phases = _build_phases(ctx)
+
+        assert phases[0].routing_headers == tuple(routing_headers)
 
     @pytest.mark.unit
     def test_warmup_enabled_produces_two_phases(self, base_rt_settings, simple_dataset):

--- a/tests/unit/config/test_yaml_loader.py
+++ b/tests/unit/config/test_yaml_loader.py
@@ -72,6 +72,40 @@ endpoint_config:
         assert config.settings.client.transport.recv_buffer_size == 16777216
         assert config.settings.client.transport.send_buffer_size == 8388608
 
+    def test_load_agentic_routing_headers(self, tmp_path):
+        config_file = tmp_path / "agentic_routing_headers.yaml"
+        config_file.write_text(
+            """
+type: online
+model_params:
+  name: test-model
+datasets:
+  - name: agentic
+    type: performance
+    path: agentic.jsonl
+    agentic_inference:
+      routing_headers:
+        - X-Session-ID
+        - X-SMG-Routing-Key
+settings:
+  load_pattern:
+    type: agentic_inference
+    target_concurrency: 8
+endpoint_config:
+  endpoints:
+    - http://localhost:8000
+"""
+        )
+
+        config = BenchmarkConfig.from_yaml_file(config_file)
+
+        agentic_config = config.datasets[0].agentic_inference
+        assert agentic_config is not None
+        assert agentic_config.routing_headers == (
+            "X-Session-ID",
+            "X-SMG-Routing-Key",
+        )
+
     def test_load_nonexistent_file(self):
         """Test error when file doesn't exist."""
         with pytest.raises(FileNotFoundError, match="not found"):

--- a/tests/unit/load_generator/test_async_session.py
+++ b/tests/unit/load_generator/test_async_session.py
@@ -143,7 +143,9 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
+        phase_issuer = PhaseIssuer(
+            dataset, issuer, publisher, lambda: False, routing_headers=()
+        )
 
         result = phase_issuer.issue(3)
         assert result is not None
@@ -203,7 +205,9 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(ChatDataset(1), issuer, publisher, lambda: False)
+        phase_issuer = PhaseIssuer(
+            ChatDataset(1), issuer, publisher, lambda: False, routing_headers=()
+        )
 
         phase_issuer.issue(0, conversation_id="conv-1", turn=2)
 
@@ -225,7 +229,9 @@ class TestPhaseIssuer:
 
         issuer = FakeIssuer()
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(MessagesDataset(1), issuer, publisher, lambda: False)
+        phase_issuer = PhaseIssuer(
+            MessagesDataset(1), issuer, publisher, lambda: False, routing_headers=()
+        )
 
         phase_issuer.issue(0)
 
@@ -239,7 +245,11 @@ class TestPhaseIssuer:
                 return {"input_tokens": [1, 2], "token_ids": [3, 4]}
 
         phase_issuer = PhaseIssuer(
-            ConflictingTokensDataset(1), FakeIssuer(), FakePublisher(), lambda: False
+            ConflictingTokensDataset(1),
+            FakeIssuer(),
+            FakePublisher(),
+            lambda: False,
+            routing_headers=(),
         )
 
         with pytest.raises(ValueError, match="both input_tokens and token_ids"):
@@ -253,7 +263,11 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         publisher = FakePublisher()
         phase_issuer = PhaseIssuer(
-            EmptyMessagesDataset(1), issuer, publisher, lambda: False
+            EmptyMessagesDataset(1),
+            issuer,
+            publisher,
+            lambda: False,
+            routing_headers=(),
         )
 
         phase_issuer.issue(0)
@@ -270,7 +284,11 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         publisher = FakePublisher()
         phase_issuer = PhaseIssuer(
-            UnsupportedPromptDataset(2), issuer, publisher, lambda: False
+            UnsupportedPromptDataset(2),
+            issuer,
+            publisher,
+            lambda: False,
+            routing_headers=(),
         )
 
         with caplog.at_level("WARNING"):
@@ -285,7 +303,11 @@ class TestPhaseIssuer:
                 return ["prompt"]
 
         phase_issuer = PhaseIssuer(
-            NonMappingDataset(2), FakeIssuer(), FakePublisher(), lambda: False
+            NonMappingDataset(2),
+            FakeIssuer(),
+            FakePublisher(),
+            lambda: False,
+            routing_headers=(),
         )
 
         with caplog.at_level("WARNING"):
@@ -304,7 +326,9 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: True)
+        phase_issuer = PhaseIssuer(
+            dataset, issuer, publisher, lambda: True, routing_headers=()
+        )
 
         result = phase_issuer.issue(0)
         assert result is None
@@ -315,7 +339,9 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
+        phase_issuer = PhaseIssuer(
+            dataset, issuer, publisher, lambda: False, routing_headers=()
+        )
 
         ids = [phase_issuer.issue(i % 5) for i in range(10)]
         assert len(set(ids)) == 10
@@ -325,11 +351,20 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
+        routing_headers = ("X-Session-ID", "X-SMG-Routing-Key")
+        phase_issuer = PhaseIssuer(
+            dataset,
+            issuer,
+            publisher,
+            lambda: False,
+            routing_headers=routing_headers,
+        )
 
         query_id = phase_issuer.issue(2, conversation_id="conv-1", turn=3)
         assert query_id is not None
-        assert issuer.issued_queries[0].headers == {"X-Session-ID": "conv-1"}
+        assert issuer.issued_queries[0].headers == dict.fromkeys(
+            routing_headers, "conv-1"
+        )
         assert phase_issuer.uuid_to_conv_info[query_id] == ("conv-1", 3)
 
         issued = publisher.events_of_type(SampleEventType.ISSUED)
@@ -343,7 +378,9 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
+        phase_issuer = PhaseIssuer(
+            dataset, issuer, publisher, lambda: False, routing_headers=()
+        )
 
         qid = phase_issuer.register_skipped(2, conversation_id="c1", turn=4)
 
@@ -371,6 +408,7 @@ class TestPhaseIssuer:
             issuer,
             publisher,
             lambda: False,
+            routing_headers=(),
             on_inflight_drained=lambda: drained.append(True),
         )
 
@@ -382,7 +420,11 @@ class TestPhaseIssuer:
 
     def test_register_skipped_returns_none_when_stopped(self):
         phase_issuer = PhaseIssuer(
-            FakeDataset(5), FakeIssuer(), FakePublisher(), lambda: True
+            FakeDataset(5),
+            FakeIssuer(),
+            FakePublisher(),
+            lambda: True,
+            routing_headers=(),
         )
         assert phase_issuer.register_skipped(0) is None
         assert phase_issuer.issued_count == 0
@@ -837,7 +879,9 @@ class TestBenchmarkSession:
         publisher = FakePublisher()
         session = BenchmarkSession(issuer, publisher, loop)
 
-        phase_issuer = PhaseIssuer(FakeDataset(3), issuer, publisher, lambda: False)
+        phase_issuer = PhaseIssuer(
+            FakeDataset(3), issuer, publisher, lambda: False, routing_headers=()
+        )
         session._current_phase_issuer = phase_issuer
 
         # Streaming path: entry stays available for the terminal COMPLETE pop.
@@ -1233,7 +1277,9 @@ class TestBenchmarkSessionHandleResponse:
         dataset = FakeDataset(1)
         issuer = FakeIssuer()
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
+        phase_issuer = PhaseIssuer(
+            dataset, issuer, publisher, lambda: False, routing_headers=()
+        )
 
         phase_issuer.uuid_to_index["q-late"] = 0
         phase_issuer.completed_uuids.add("q-late")

--- a/tests/unit/load_generator/test_async_session.py
+++ b/tests/unit/load_generator/test_async_session.py
@@ -143,9 +143,7 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(
-            dataset, issuer, publisher, lambda: False, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
 
         result = phase_issuer.issue(3)
         assert result is not None
@@ -205,9 +203,7 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(
-            ChatDataset(1), issuer, publisher, lambda: False, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(ChatDataset(1), issuer, publisher, lambda: False)
 
         phase_issuer.issue(0, conversation_id="conv-1", turn=2)
 
@@ -229,9 +225,7 @@ class TestPhaseIssuer:
 
         issuer = FakeIssuer()
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(
-            MessagesDataset(1), issuer, publisher, lambda: False, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(MessagesDataset(1), issuer, publisher, lambda: False)
 
         phase_issuer.issue(0)
 
@@ -245,11 +239,7 @@ class TestPhaseIssuer:
                 return {"input_tokens": [1, 2], "token_ids": [3, 4]}
 
         phase_issuer = PhaseIssuer(
-            ConflictingTokensDataset(1),
-            FakeIssuer(),
-            FakePublisher(),
-            lambda: False,
-            routing_headers=(),
+            ConflictingTokensDataset(1), FakeIssuer(), FakePublisher(), lambda: False
         )
 
         with pytest.raises(ValueError, match="both input_tokens and token_ids"):
@@ -263,11 +253,7 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         publisher = FakePublisher()
         phase_issuer = PhaseIssuer(
-            EmptyMessagesDataset(1),
-            issuer,
-            publisher,
-            lambda: False,
-            routing_headers=(),
+            EmptyMessagesDataset(1), issuer, publisher, lambda: False
         )
 
         phase_issuer.issue(0)
@@ -284,11 +270,7 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         publisher = FakePublisher()
         phase_issuer = PhaseIssuer(
-            UnsupportedPromptDataset(2),
-            issuer,
-            publisher,
-            lambda: False,
-            routing_headers=(),
+            UnsupportedPromptDataset(2), issuer, publisher, lambda: False
         )
 
         with caplog.at_level("WARNING"):
@@ -303,11 +285,7 @@ class TestPhaseIssuer:
                 return ["prompt"]
 
         phase_issuer = PhaseIssuer(
-            NonMappingDataset(2),
-            FakeIssuer(),
-            FakePublisher(),
-            lambda: False,
-            routing_headers=(),
+            NonMappingDataset(2), FakeIssuer(), FakePublisher(), lambda: False
         )
 
         with caplog.at_level("WARNING"):
@@ -326,9 +304,7 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(
-            dataset, issuer, publisher, lambda: True, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: True)
 
         result = phase_issuer.issue(0)
         assert result is None
@@ -339,9 +315,7 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(
-            dataset, issuer, publisher, lambda: False, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
 
         ids = [phase_issuer.issue(i % 5) for i in range(10)]
         assert len(set(ids)) == 10
@@ -378,9 +352,7 @@ class TestPhaseIssuer:
         issuer = FakeIssuer()
         issuer._auto_respond = False
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(
-            dataset, issuer, publisher, lambda: False, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
 
         qid = phase_issuer.register_skipped(2, conversation_id="c1", turn=4)
 
@@ -408,7 +380,6 @@ class TestPhaseIssuer:
             issuer,
             publisher,
             lambda: False,
-            routing_headers=(),
             on_inflight_drained=lambda: drained.append(True),
         )
 
@@ -420,11 +391,7 @@ class TestPhaseIssuer:
 
     def test_register_skipped_returns_none_when_stopped(self):
         phase_issuer = PhaseIssuer(
-            FakeDataset(5),
-            FakeIssuer(),
-            FakePublisher(),
-            lambda: True,
-            routing_headers=(),
+            FakeDataset(5), FakeIssuer(), FakePublisher(), lambda: True
         )
         assert phase_issuer.register_skipped(0) is None
         assert phase_issuer.issued_count == 0
@@ -879,9 +846,7 @@ class TestBenchmarkSession:
         publisher = FakePublisher()
         session = BenchmarkSession(issuer, publisher, loop)
 
-        phase_issuer = PhaseIssuer(
-            FakeDataset(3), issuer, publisher, lambda: False, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(FakeDataset(3), issuer, publisher, lambda: False)
         session._current_phase_issuer = phase_issuer
 
         # Streaming path: entry stays available for the terminal COMPLETE pop.
@@ -1277,9 +1242,7 @@ class TestBenchmarkSessionHandleResponse:
         dataset = FakeDataset(1)
         issuer = FakeIssuer()
         publisher = FakePublisher()
-        phase_issuer = PhaseIssuer(
-            dataset, issuer, publisher, lambda: False, routing_headers=()
-        )
+        phase_issuer = PhaseIssuer(dataset, issuer, publisher, lambda: False)
 
         phase_issuer.uuid_to_index["q-late"] = 0
         phase_issuer.completed_uuids.add("q-late")


### PR DESCRIPTION
## Summary

- add a YAML-configurable list of routing headers for agentic inference requests
- populate each configured header with the conversation ID
- preserve `X-Session-ID` as the default when `routing_headers` is omitted
- allow `routing_headers: []` to disable conversation routing headers

Example:

```yaml
agentic_inference:
  routing_headers:
    - X-Session-ID
    - X-SMG-Routing-Key
```

## Validation

- `uv run pytest -q tests/unit/load_generator/test_async_session.py tests/unit/config/test_yaml_loader.py tests/unit/commands/test_benchmark.py::TestBuildPhases` (81 passed)
- `uv run pre-commit run --all-files`
