### PR TITLE
fix(swebench-service): let srun find its config and honour proxy policy

### DIFF
--- a/src/inference_endpoint/evaluation/swebench_service/README.md
+++ b/src/inference_endpoint/evaluation/swebench_service/README.md
@@ -54,6 +54,16 @@ registry requires authentication. Launch the service on the compute node inside 
 active one-node Slurm allocation. The runtime requires `SLURM_JOB_ID` and
 `SLURMD_NODENAME` and assumes the node is exclusive to the user.
 
+Each `srun` step is given an explicit allow-list of environment variables rather
+than the service's whole environment, so that inherited `SLURM_JOB_ID` /
+`SLURM_STEP_ID` cannot corrupt a nested `srun`. Two entries on that list are load
+bearing on real clusters: `SLURM_CONF`, without which the child `srun` falls back
+to `/etc/slurm/slurm.conf` and aborts on a configless or multi-cluster site; and
+the proxy variables (`http_proxy`, `https_proxy`, `no_proxy` and their uppercase
+forms), which Enroot needs because it performs the registry pull inside the step.
+Credentials such as `OPENAI_API_KEY`, `HF_TOKEN` and the service auth token are
+never forwarded.
+
 During generation, the service still uses mini-swe-agent for the agent loop and
 model requests, but replaces its Docker environment with `PyxisEnvironment`. Every
 trajectory receives a named, writable Pyxis container. Each tool call becomes an

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
@@ -30,22 +30,16 @@ _SAFE_SRUN_ENV = (
     "TMPDIR",
     "XDG_RUNTIME_DIR",
     # Proxy policy must reach enroot, which performs the registry pull inside
-    # the step. Clusters that pin a container-cache proxy system-wide 403 any
-    # registry outside its allow-list, and without no_proxy every per-instance
-    # image import fails with "CONNECT tunnel failed, response 403".
+    # the step.
+    "all_proxy",
     "http_proxy",
     "https_proxy",
     "no_proxy",
+    "ALL_PROXY",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "NO_PROXY",
-    # srun locates its own configuration through SLURM_CONF. Dropping it makes
-    # the child fall back to /etc/slurm/slurm.conf, which on a configless or
-    # multi-cluster site is either absent ("Could not establish a configuration
-    # source") or a different file whose plugins are not installed
-    # ("failed to initialize cli_filter plugin"). Every step then fails before
-    # the container is ever created. The remaining SLURM_* variables stay out:
-    # inheriting SLURM_JOB_ID / SLURM_STEP_ID is what breaks a nested srun.
+    # srun locates its own configuration through SLURM_CONF.
     "SLURM_CONF",
 )
 _STEP_STATUS = "/tmp/.mlperf_srun_status"

--- a/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
+++ b/src/inference_endpoint/evaluation/swebench_service/swebench_service/pyxis_environment.py
@@ -29,6 +29,24 @@ _SAFE_SRUN_ENV = (
     "LC_ALL",
     "TMPDIR",
     "XDG_RUNTIME_DIR",
+    # Proxy policy must reach enroot, which performs the registry pull inside
+    # the step. Clusters that pin a container-cache proxy system-wide 403 any
+    # registry outside its allow-list, and without no_proxy every per-instance
+    # image import fails with "CONNECT tunnel failed, response 403".
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    # srun locates its own configuration through SLURM_CONF. Dropping it makes
+    # the child fall back to /etc/slurm/slurm.conf, which on a configless or
+    # multi-cluster site is either absent ("Could not establish a configuration
+    # source") or a different file whose plugins are not installed
+    # ("failed to initialize cli_filter plugin"). Every step then fails before
+    # the container is ever created. The remaining SLURM_* variables stay out:
+    # inheriting SLURM_JOB_ID / SLURM_STEP_ID is what breaks a nested srun.
+    "SLURM_CONF",
 )
 _STEP_STATUS = "/tmp/.mlperf_srun_status"
 _STEP_SCRIPT = r"""set +e

--- a/tests/unit/evaluation/swebench_service/test_runner.py
+++ b/tests/unit/evaluation/swebench_service/test_runner.py
@@ -835,6 +835,40 @@ def test_pyxis_srun_environment_does_not_forward_credentials(monkeypatch):
     assert "HF_TOKEN" not in environment
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        # srun locates its own configuration through SLURM_CONF; without it a
+        # configless or multi-cluster site aborts every step before a container
+        # is created.
+        "SLURM_CONF",
+        # enroot performs the registry pull inside the step and needs the same
+        # proxy policy as the caller.
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+    ],
+)
+def test_pyxis_srun_environment_forwards_config_and_proxy_policy(monkeypatch, name):
+    monkeypatch.setenv(name, "value")
+
+    assert safe_srun_env().get(name) == "value"
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["SLURM_JOB_ID", "SLURM_STEP_ID", "SLURM_NTASKS", "SLURM_NNODES", "SLURM_PROCID"],
+)
+def test_pyxis_srun_environment_withholds_inherited_step_identity(monkeypatch, name):
+    """Only SLURM_CONF is forwarded; step identity would break a nested srun."""
+    monkeypatch.setenv(name, "inherited")
+
+    assert name not in safe_srun_env()
+
+
 def test_pyxis_environment_reuses_named_writable_container(
     monkeypatch, tmp_path, caplog
 ):


### PR DESCRIPTION
The Pyxis runtime builds each container step's environment from an explicit allow-list, and two variables that srun and enroot genuinely need were missing. Neither failure is visible in a unit test, because both live in the environment handed to a subprocess we mock.

SLURM_CONF. Without it the child srun falls back to /etc/slurm/slurm.conf. On a configless site that file does not exist and srun aborts with "Could not establish a configuration source"; on a multi-cluster site it exists but is a different cluster's file whose plugins are not installed locally, and srun aborts with "failed to initialize cli_filter plugin". Either way every step dies before a container is created, and the run reports only the generic "Pyxis infrastructure failure before the command completed". The remaining SLURM_* variables stay out of the allow-list deliberately: inheriting SLURM_JOB_ID / SLURM_STEP_ID is exactly what breaks a nested srun, which is why the allow-list exists.

Proxy policy. enroot performs the registry pull inside the step, so it needs the same proxy configuration as the caller. A site that pins a container-cache proxy system-wide will 403 the CONNECT for any registry outside that cache's allow-list, and every per-instance image import fails with "curl: (56) CONNECT tunnel failed, response 403" -- including the SWE-bench task images this runtime is built to pull.

Verified on a GB200 cluster whose enroot pins a container cache: before the change no sweb.eval.arm64 image could be imported from any node; after it, the image imports and the container starts.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

