### PR TITLE
Agentic Inference: Update accuracy methodology for agentic and Qwen 3.6's threshold to 69%

### DIFF
--- a/examples/10_Agentic_Inference/README.md
+++ b/examples/10_Agentic_Inference/README.md
@@ -187,7 +187,7 @@ Official submissions must enable both inline accuracy and SWE-bench accuracy. Co
 
 Qwen3.6-35B-A3B submissions must set `accuracy_config.extras.swebench_template: qwen_tools`. Kimi K2.6 submissions must omit `accuracy_config.extras.swebench_template`.
 
-Every submitted Pareto point must satisfy all of the following accuracy thresholds, except that Qwen3.6-35B-A3B SWE-bench accuracy is evaluated using mean-of-N across the four mandatory regions (`N = 4`). The Qwen SWE-bench threshold below applies to that arithmetic mean.
+Every submitted Pareto point must satisfy all of the following accuracy thresholds, except that SWE-bench accuracy is evaluated using mean-of-N for both models. For each model, average one SWE-bench accuracy result from each of the [four mandatory regions](https://github.com/mlcommons/endpoints_policies/blob/main/endpoints_rules.md#54-regions-of-interest) (`N = 4`), then compare that mean with the model-specific SWE-bench threshold below.
 
 | Metric             |        Kimi K2.6 |  Qwen3.6-35B-A3B |
 | ------------------ | ---------------: | ---------------: |

--- a/examples/10_Agentic_Inference/README.md
+++ b/examples/10_Agentic_Inference/README.md
@@ -187,13 +187,13 @@ Official submissions must enable both inline accuracy and SWE-bench accuracy. Co
 
 Qwen3.6-35B-A3B submissions must set `accuracy_config.extras.swebench_template: qwen_tools`. Kimi K2.6 submissions must omit `accuracy_config.extras.swebench_template`.
 
-Every submitted Pareto point must satisfy all of the following accuracy thresholds:
+Every submitted Pareto point must satisfy all of the following accuracy thresholds, except that Qwen3.6-35B-A3B SWE-bench accuracy is evaluated using mean-of-N across the four mandatory regions (`N = 4`). The Qwen SWE-bench threshold below applies to that arithmetic mean.
 
 | Metric             |        Kimi K2.6 |  Qwen3.6-35B-A3B |
 | ------------------ | ---------------: | ---------------: |
 | Inline accuracy    |      `>= 63.08%` |      `>= 55.86%` |
 | OSL per-turn mean  | `404-494` tokens | `355-434` tokens |
-| SWE-bench accuracy |       `>= 76.5%` |       `>= 67.5%` |
+| SWE-bench accuracy |       `>= 76.5%` |         `>= 69%` |
 
 ### Speculative Decoding
 


### PR DESCRIPTION
## What does this PR do?

In relation to the endpoints policy update on per-region accuracy evaluation on the pareto. This change reflects that policy as well as the inclusion of mean-of-N methodology to tighten up the variance.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor/cleanup
