### PR TITLE
fix(lcb-service): pin base image to Python 3.11 to match LiveCodeBench

### DIFF
--- a/src/inference_endpoint/evaluation/livecodebench/lcb_serve.dockerfile
+++ b/src/inference_endpoint/evaluation/livecodebench/lcb_serve.dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 
 ## -----------------------------------------------------
-FROM dhi.io/python:3.14-debian13-sfw-dev AS build-stage
+# Mirrors LiveCodeBench's own Python version (README: `uv venv --python 3.11`).
+FROM dhi.io/python:3.11-debian13-sfw-dev AS build-stage
 
 
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -32,7 +33,7 @@ RUN chmod 444 -R /opt/LiveCodeBench_Datasets/*
 RUN chmod 555 /opt/LiveCodeBench_Datasets
 
 ## -----------------------------------------------------
-FROM dhi.io/python:3.14-debian13 AS runtime-stage
+FROM dhi.io/python:3.11-debian13 AS runtime-stage
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
LiveCodeBench requires Python >= 3.10, and its README uses `uv venv --python 3.11`. Switch both build/runtime stages from dhi.io/python:3.14-debian13(-sfw-dev) to dhi.io/python:3.11-debian13(-sfw-dev) to match.


This is related to https://github.com/mlcommons/endpoints/pull/433
https://github.com/mlcommons/endpoints/pull/433#issuecomment-5293679069

Python 3.14 changed the Linux multiprocessing default to forkserver. With the shipped Python 3.14 service image, grading child processes died during startup, leaving evaluation stuck at 0/N.

After discussion, the current conclusion is to revert the base image to Python 3.11. An explicit spawn solution is still worth investigating, but it needs additional performance evaluation before we consider adopting it.




## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
