### PR TITLE
fix(deps): bump pip → 26.2 (PYSEC-2026-3721)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,9 @@ dev = [
     # CVE-2026-22701 (filelock) and CVE-2026-22702 (virtualenv).
     "filelock>=3.20.3",
     "virtualenv>=20.36.1",
+    # pip is pulled in transitively (pip-audit -> pip-api -> pip); force past
+    # PYSEC-2026-3721 (fixed in 26.2), which otherwise fails `uv run pip-audit`.
+    "pip==26.2",
 ]
 test = [
     # Includes optional dependencies for full test coverage

--- a/uv.lock
+++ b/uv.lock
@@ -1346,6 +1346,7 @@ dev = [
     { name = "filelock", version = "3.25.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "line-profiler", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "myst-parser", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pip", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pip-audit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pre-commit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pympler", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1404,6 +1405,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "openai-harmony", specifier = "==0.0.8" },
     { name = "pillow", specifier = "==12.3.0" },
+    { name = "pip", marker = "extra == 'dev'", specifier = "==26.2" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = "==2.10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.5.1" },
     { name = "protobuf", specifier = "==7.34.1" },
@@ -2482,11 +2484,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/96/e6f8e9d9d7b9cc4457092712a7e919c3186aa2c2fa9ffed2c5d29cc947e8/pip-26.2.tar.gz", hash = "sha256:2d8542afcc84cdd8e846c2b36b2861fad1da376dd98f8e7113e9108a3c331690", size = 1848845, upload-time = "2026-07-29T21:57:56.407Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/62/36/a3aed958d60531cb442b7ab4596cda7b3621cfb916f8ae1d6769795c7dc1/pip-26.2-py3-none-any.whl", hash = "sha256:931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad", size = 1816475, upload-time = "2026-07-29T21:57:54.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The `Tests` workflow's **`audit`** job (`uv run pip-audit`, `.github/workflows/test.yml:74-75`) is failing on `main` on every commit — not from a code regression but because a newly-published advisory now flags the pip version in the environment:

```
Found 1 known vulnerability in 1 package
Name Version ID              Fix Versions
pip  26.1.2  PYSEC-2026-3721 26.2
```

`pip` is pulled in transitively (`pip-audit` → `pip-api` → `pip`) and nothing pinned it forward, so `main` went red the moment the advisory was published, independent of HEAD. Same failure class as #460 (`datasets` / PYSEC-2026-3716).

## Fix

Force `pip==26.2` in the `dev` extra, next to the existing `filelock` / `virtualenv` CVE floors that follow the same transitive-dep pattern. Lock delta is only pip 26.1.2 → 26.2.

## Verification

- `uv run pip-audit` → **No known vulnerabilities found** ✅
- Lock delta confirmed surgical (only pip moved).
- Local `pytest`/`mypy` noise (ZMQ IPC socket-path length > 103, Linux-only `os.sched_*`) is pre-existing macOS-only and reproduces identically on clean `main`; both pass on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)