### PR TITLE
fix(metrics): weight gpt-oss accuracy by dataset sample count to matc…

### DIFF
--- a/src/inference_endpoint/commands/benchmark/accuracy.py
+++ b/src/inference_endpoint/commands/benchmark/accuracy.py
@@ -41,7 +41,9 @@ from inference_endpoint.async_utils.services.metrics_aggregator.token_metrics im
 from inference_endpoint.config.schema import DatasetType, ScorerMethod, TestMode
 from inference_endpoint.dataset_manager.dataset import Dataset
 from inference_endpoint.evaluation import Extractor
-from inference_endpoint.evaluation.accuracy_results import average_accuracy
+from inference_endpoint.evaluation.accuracy_results import (
+    samples_weighted_average_accuracy,
+)
 from inference_endpoint.evaluation.scoring import Scorer
 from inference_endpoint.exceptions import ExecutionError, InputValidationError
 from inference_endpoint.load_generator.session import SessionResult
@@ -395,9 +397,10 @@ def write_accuracy_results(
     """
     if not accuracy_scores:
         return
-    # Plain cross-component mean of the per-dataset scores (3 datasets for
-    # gpt-oss, 1 for DeepSeek-R1); None when nothing numeric was scored.
-    avg_accuracy = average_accuracy(accuracy_scores)
+    # Sample-count-weighted cross-component mean of the per-dataset scores
+    # (weight = each dataset's unit_samples; 3 datasets for gpt-oss, 1 for
+    # DeepSeek-R1); None when nothing numeric was scored.
+    avg_accuracy = samples_weighted_average_accuracy(accuracy_scores)
     # Total finalize-time spent tokenizing accuracy outputs for OSL (seconds),
     # summed across datasets. Emitted whenever OSL was computed for at least
     # one dataset — gating on the key's presence, not the rounded wall-clock,
@@ -411,6 +414,9 @@ def write_accuracy_results(
     accuracy_results_path = accuracy_dir / "accuracy_results.json"
     accuracy_payload: dict[str, Any] = {}
     if avg_accuracy is not None:
+        # Stable artifact key: kept as "average_accuracy" even though the value is
+        # now the sample-weighted mean, so existing accuracy_results.json consumers
+        # don't break on a rename. The value semantics changed, not the key.
         accuracy_payload["average_accuracy"] = avg_accuracy
     if osl_computed:
         accuracy_payload["osl_tokenization_s"] = osl_tokenization_s

--- a/src/inference_endpoint/evaluation/accuracy_results.py
+++ b/src/inference_endpoint/evaluation/accuracy_results.py
@@ -26,8 +26,9 @@ back from the entry's ``score``.
 
 This module owns that contract: the breakdown constructor
 (:func:`build_breakdown`), the readers (:func:`find_accuracy_entry` /
-:func:`find_accuracy_breakdown`), the cross-component mean
-(:func:`average_accuracy`), and the numeric coercion (:func:`to_float`). It lives
+:func:`find_accuracy_breakdown`), the sample-count-weighted cross-component mean
+(:func:`samples_weighted_average_accuracy`), and the numeric coercion
+(:func:`to_float`). It lives
 under ``evaluation`` — the layer that *produces* breakdowns — so ``metrics`` and
 ``compliance`` can both import it without a cycle.
 """
@@ -86,35 +87,69 @@ def find_accuracy_breakdown(results: dict[str, Any]) -> dict[str, Any] | None:
     return entry.get("breakdown") if entry is not None else None
 
 
-def average_accuracy(accuracy_scores: list[dict[str, Any]]) -> float | None:
-    """Plain mean of the per-dataset scalar scores across accuracy components.
+def samples_weighted_average_accuracy(
+    accuracy_scores: list[dict[str, Any]],
+) -> float | None:
+    """Sample-count-weighted mean of the per-dataset scalar scores.
 
-    One component per accuracy dataset (3 for gpt-oss, 1 for DeepSeek-R1), so the
-    result equals the single dataset's score when there is only one. The inline
-    perf-scored entry (``dataset_type == "performance"``) — a scored perf dataset,
-    not an accuracy component — and any non-numeric score are excluded. Excluding
-    by the ``dataset_type`` discriminator (not by ``dataset_name == "performance"``)
-    means a dataset legitimately named ``performance`` is still counted. Returns
-    ``None`` when no component has a numeric score.
+    Each accuracy component is weighted by its dataset sample count — the
+    ``unit_samples`` field, which is ``dataset.num_samples()`` (the number of rows
+    in the loaded dataset, e.g. 30 AIME / 198 GPQA / 1055 LiveCodeBench problems),
+    NOT ``total_samples`` (``unit_samples × repeats``, the issued attempts). This
+    reproduces the MLCommons gpt-oss reference aggregation that feeds the
+    submission ``exact_match``::
 
-    Assumes the components share a scale — real runs score one model's same-family
-    datasets (gpt-oss: three fraction ``[0, 1]`` scorers; DeepSeek-R1: one
-    percentage ``[0, 100]`` scorer). A hypothetical run mixing scales would yield a
-    meaningless mean, but magnitude alone can't tell a fraction from a low
-    percentage, so this does not guess; homogenizing the scorer ``score()``
-    contract to one unit is tracked separately.
+        overall = Σ(score_d · unit_samples_d) / Σ unit_samples_d
+
+    Because ``score_d = correct_d / (unit_samples_d · repeats_d)``, the numerator
+    term equals ``correct_d / repeats_d`` — i.e. each dataset is normalized
+    per-repeat before combining, so it contributes in proportion to its unique
+    problems regardless of how many repeats it ran. A plain unweighted mean
+    over-weights small datasets (AIME's 30 problems counting equally with
+    LiveCodeBench's 1055) and does not match the reference; weighting by
+    ``total_samples`` (issued attempts) instead yields the reference's *raw*
+    accuracy, which is not the submitted score.
+
+    With one component the weight cancels and the result is that dataset's score
+    (DeepSeek-R1). The inline perf-scored entry (``dataset_type == "performance"``)
+    and any non-numeric score are excluded; exclusion is by the ``dataset_type``
+    discriminator, so a dataset legitimately named ``performance`` still counts.
+    A component with ``unit_samples`` absent/``None`` falls back to weight ``1.0``
+    (legacy artifacts predating the field; runs produced by this tool always record
+    it — ``accuracy.py``), while a *present but* non-positive/non-numeric weight is
+    treated as corrupt and the component is skipped rather than counted as one
+    sample. Returns ``None`` when no component contributes a numeric score.
+
+    Assumes the components share a scale (gpt-oss: fractions ``[0, 1]``;
+    DeepSeek-R1: one percentage ``[0, 100]``); it does not homogenize units.
     """
-    values = [
-        float(entry["score"])
-        for entry in accuracy_scores
-        if isinstance(entry, dict)
-        and entry.get("dataset_type") != DatasetType.PERFORMANCE.value
-        and isinstance(entry.get("score"), int | float)
-        and not isinstance(entry.get("score"), bool)
-    ]
-    if not values:
+    numerator = 0.0
+    denominator = 0.0
+    for entry in accuracy_scores:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("dataset_type") == DatasetType.PERFORMANCE.value:
+            continue
+        score = entry.get("score")
+        if not isinstance(score, int | float) or isinstance(score, bool):
+            continue
+        weight = entry.get("unit_samples")
+        if weight is None:
+            # Legacy artifacts predating unit_samples: contribute unweighted.
+            weight = 1.0
+        elif (
+            isinstance(weight, bool)
+            or not isinstance(weight, int | float)
+            or weight <= 0
+        ):
+            # Present but non-positive / non-numeric — a corrupt weight; skip the
+            # entry rather than invent a sample count that would skew the mean.
+            continue
+        numerator += float(score) * float(weight)
+        denominator += float(weight)
+    if denominator == 0:
         return None
-    return sum(values) / len(values)
+    return numerator / denominator
 
 
 def build_breakdown(

--- a/src/inference_endpoint/metrics/report.py
+++ b/src/inference_endpoint/metrics/report.py
@@ -32,7 +32,9 @@ from inference_endpoint.async_utils.services.metrics_aggregator.aggregator impor
 from inference_endpoint.async_utils.services.metrics_aggregator.registry import (
     build_token_series_dict,
 )
-from inference_endpoint.evaluation.accuracy_results import average_accuracy
+from inference_endpoint.evaluation.accuracy_results import (
+    samples_weighted_average_accuracy,
+)
 from inference_endpoint.utils.version import get_version_info
 
 from ..utils import monotime_to_datetime
@@ -501,7 +503,7 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
                         fn(f"    {sub}: {sub_score:.2f}%{newline}")
                 if entry.get("complete") is False:
                     fn(f"    (incomplete){newline}")
-            avg = average_accuracy(self.accuracy)
+            avg = samples_weighted_average_accuracy(self.accuracy)
             if avg is not None:
                 fn(f"  Average: {avg:.4g}{newline}")
             if any("osl_tokenize_s" in e for e in self.accuracy):

--- a/src/inference_endpoint/metrics/results_plots.py
+++ b/src/inference_endpoint/metrics/results_plots.py
@@ -106,13 +106,17 @@ def _breakdown_from_scalars(results: dict[str, Any]) -> AccuracyBreakdown | None
     gpt-oss runs three single-metric datasets (``aime25``/``gpqa``/``lcb``) scored
     by ``PassAt1Scorer``/``LiveCodeBenchScorer``, which don't emit a
     ``score_breakdown``. Without this, ``extract_accuracy`` returns ``None`` and
-    the accuracy plot is empty. One bar per accuracy dataset; overall is their mean.
+    the accuracy plot is empty. One bar per accuracy dataset; overall is their
+    unit_samples-weighted mean — the same weighting as the ``average_accuracy``
+    JSON artifact key — kept consistent with the bars below.
     """
     scores = results.get("accuracy_scores")
     if not isinstance(scores, list):
         return None
     subset: dict[str, float] = {}
     total = 0
+    weighted_sum = 0.0
+    weight_total = 0.0
     for e in scores:
         if (
             not isinstance(e, dict)
@@ -124,11 +128,25 @@ def _breakdown_from_scalars(results: dict[str, Any]) -> AccuracyBreakdown | None
             # Scalar scorers (PassAt1Scorer/LiveCodeBenchScorer) return fractions
             # in [0, 1], but plot_accuracy renders on a 0-100 axis and gates in
             # percent — scale fractions up so gpt-oss bars read 80, not 0.8.
-            subset[str(e.get("dataset_name", "?"))] = s * 100 if s <= 1 else s
+            pct = s * 100 if s <= 1 else s
+            subset[str(e.get("dataset_name", "?"))] = pct
             total += int(e.get("total_samples", 0) or 0)
+            # Weight each bar by its dataset sample count so ``overall`` is the same
+            # unit_samples-weighted mean as accuracy_results.json average_accuracy,
+            # yet derived from the exact values shown as bars — so a rendered bar can
+            # never be silently dropped from the headline. An absent/invalid count
+            # contributes weight 1.0 (every bar counts).
+            w = e.get("unit_samples")
+            weight = (
+                float(w)
+                if isinstance(w, int | float) and not isinstance(w, bool) and w > 0
+                else 1.0
+            )
+            weighted_sum += pct * weight
+            weight_total += weight
     if not subset:
         return None
-    overall = sum(subset.values()) / len(subset)
+    overall = weighted_sum / weight_total
     return AccuracyBreakdown(
         overall=overall,
         normalized=overall,

--- a/tests/unit/commands/test_score_accuracy.py
+++ b/tests/unit/commands/test_score_accuracy.py
@@ -30,6 +30,7 @@ from inference_endpoint.commands.benchmark.accuracy import (
     _phase_osl_stats,
     _phase_response_counts,
     score_accuracy,
+    write_accuracy_results,
 )
 from inference_endpoint.config import schema as config_schema
 from inference_endpoint.config.schema import (
@@ -684,3 +685,23 @@ class TestPhaseDuration:
         # must accept the coerced entry.
         json.dumps(entry)
         msgspec.json.encode(entry)
+
+
+@pytest.mark.unit
+def test_write_accuracy_results_keeps_stable_average_accuracy_key(tmp_path):
+    # The Python aggregator was renamed to samples_weighted_average_accuracy, but
+    # the JSON artifact key is intentionally frozen as "average_accuracy" so
+    # existing accuracy_results.json consumers keep working. Lock the key name and
+    # that its value is the unit_samples-weighted mean (627/1030, not the flat 0.75).
+    scores = [
+        {"dataset_name": "aime", "score": 0.9, "unit_samples": 30},
+        {"dataset_name": "lcb", "score": 0.6, "unit_samples": 1000},
+    ]
+    write_accuracy_results(tmp_path, scores)
+    data = msgspec.json.decode(
+        (tmp_path / "accuracy" / "accuracy_results.json").read_bytes()
+    )
+    assert "average_accuracy" in data
+    assert "samples_weighted_average_accuracy" not in data
+    expected = (0.9 * 30 + 0.6 * 1000) / (30 + 1000)
+    assert data["average_accuracy"] == pytest.approx(expected)

--- a/tests/unit/evaluation/test_accuracy_results.py
+++ b/tests/unit/evaluation/test_accuracy_results.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 
 import pytest
 from inference_endpoint.evaluation.accuracy_results import (
-    average_accuracy,
     build_breakdown,
     find_accuracy_breakdown,
     find_accuracy_entry,
+    samples_weighted_average_accuracy,
     to_float,
 )
 
@@ -102,16 +102,123 @@ class TestFindAccuracyBreakdown:
 
 @pytest.mark.unit
 class TestAverageAccuracy:
-    def test_multi_component_mean(self):
+    def test_multi_component_weighted_by_unit_samples(self):
+        # Components are weighted by unique-problem count (unit_samples), not
+        # averaged flat: LiveCodeBench (1055 problems) dominates AIME (30).
         scores = [
-            {"dataset_name": "aime25::gptoss", "score": 83.33},
-            {"dataset_name": "gpqa::gptoss", "score": 74.75},
-            {"dataset_name": "livecodebench::gptoss", "score": 84.74},
+            {"dataset_name": "aime25::gptoss", "score": 83.33, "unit_samples": 30},
+            {"dataset_name": "gpqa::gptoss", "score": 74.75, "unit_samples": 198},
+            {
+                "dataset_name": "livecodebench::gptoss",
+                "score": 84.74,
+                "unit_samples": 1055,
+            },
         ]
-        assert average_accuracy(scores) == pytest.approx((83.33 + 74.75 + 84.74) / 3)
+        weighted = (83.33 * 30 + 74.75 * 198 + 84.74 * 1055) / (30 + 198 + 1055)
+        assert samples_weighted_average_accuracy(scores) == pytest.approx(weighted)
+        # The weighted mean is materially different from the flat mean.
+        assert samples_weighted_average_accuracy(scores) != pytest.approx(
+            (83.33 + 74.75 + 84.74) / 3
+        )
+
+    def test_mlperf_reference_exact_match(self):
+        # Regression lock to the MLCommons gpt-oss reference calculation.
+        # aime25: 197/240 correct over 8 repeats (30 unique problems)
+        # gpqa_diamond: 752/990 over 5 repeats (198 unique)
+        # livecodebench_v6: 2684/3165 over 3 repeats (1055 unique)
+        # Reference final score: 1069.69 / 1283.00 = 83.374% ('exact_match': 83.374).
+        scores = [
+            {"dataset_name": "aime25", "score": 197 / 240, "unit_samples": 30},
+            {"dataset_name": "gpqa_diamond", "score": 752 / 990, "unit_samples": 198},
+            {
+                "dataset_name": "livecodebench_v6",
+                "score": 2684 / 3165,
+                "unit_samples": 1055,
+            },
+        ]
+        avg = samples_weighted_average_accuracy(scores)
+        assert avg is not None
+        assert round(avg * 100, 3) == 83.374
+        # Must NOT collapse to the old unweighted mean (~80.95%); this fails if the
+        # sample weighting is ever reverted to a flat mean.
+        unweighted = (197 / 240 + 752 / 990 + 2684 / 3165) / 3
+        assert avg != pytest.approx(unweighted)
+
+    def test_weight_defaults_to_one_when_unit_samples_missing(self):
+        # Legacy artifacts predating unit_samples fall back to an unweighted mean.
+        scores = [
+            {"dataset_name": "a", "score": 0.6},
+            {"dataset_name": "b", "score": 0.8},
+        ]
+        assert samples_weighted_average_accuracy(scores) == pytest.approx(0.7)
+
+    def test_explicit_none_unit_samples_defaults_to_one(self):
+        # An explicit None weight behaves like an absent key (legacy fallback).
+        scores = [
+            {"dataset_name": "a", "score": 0.6, "unit_samples": None},
+            {"dataset_name": "b", "score": 0.8, "unit_samples": None},
+        ]
+        assert samples_weighted_average_accuracy(scores) == pytest.approx(0.7)
+
+    def test_nonpositive_or_bad_weight_entries_are_skipped(self):
+        # A present-but-corrupt weight (<=0, or a non-numeric/bool type) must NOT
+        # be counted as one sample — the entry is dropped from the mean entirely,
+        # so only the well-formed component (weight 40) contributes. The negative
+        # and non-numeric cases are the real regression locks; `0` is a boundary
+        # (skipping and a zero weight yield the same mean) included for completeness.
+        for bad in (0, -5, True, "30", [30]):
+            scores = [
+                {"dataset_name": "good", "score": 0.9, "unit_samples": 40},
+                {"dataset_name": "bad", "score": 0.1, "unit_samples": bad},
+            ]
+            assert samples_weighted_average_accuracy(scores) == pytest.approx(0.9)
+
+    def test_all_weights_corrupt_returns_none(self):
+        # Every component has a present-but-invalid weight -> nothing counted.
+        scores = [
+            {"dataset_name": "a", "score": 0.5, "unit_samples": 0},
+            {"dataset_name": "b", "score": 0.7, "unit_samples": -1},
+        ]
+        assert samples_weighted_average_accuracy(scores) is None
+
+    def test_partial_missing_weight_degrades_to_one(self):
+        # Mixed shape (one real weight, one absent) is not tool-producible but must
+        # be well-defined: the absent component contributes weight 1.0, not 0.
+        scores = [
+            {"dataset_name": "big", "score": 1.0, "unit_samples": 1055},
+            {"dataset_name": "legacy", "score": 0.0},  # no unit_samples -> 1.0
+        ]
+        assert samples_weighted_average_accuracy(scores) == pytest.approx(1055 / 1056)
+
+    def test_total_samples_is_not_used_as_weight(self):
+        # Weighting must use unit_samples (unique problems), never total_samples
+        # (issued attempts) — the latter reproduces the reference's raw accuracy,
+        # not the submitted score. A large total_samples on a low-score dataset
+        # must not drag the result down when its unit_samples is small.
+        scores = [
+            {
+                "dataset_name": "aime",
+                "score": 0.9,
+                "unit_samples": 30,
+                "total_samples": 240,
+            },
+            {
+                "dataset_name": "lcb",
+                "score": 0.6,
+                "unit_samples": 30,
+                "total_samples": 3000,
+            },
+        ]
+        # Equal unit_samples -> plain mean 0.75, regardless of total_samples.
+        assert samples_weighted_average_accuracy(scores) == pytest.approx(0.75)
 
     def test_single_component_equals_itself(self):
-        assert average_accuracy([{"dataset_name": "dsr1", "score": 81.04}]) == 81.04
+        assert (
+            samples_weighted_average_accuracy(
+                [{"dataset_name": "dsr1", "score": 81.04}]
+            )
+            == 81.04
+        )
 
     def test_excludes_performance_and_non_numeric(self):
         scores = [
@@ -120,14 +227,14 @@ class TestAverageAccuracy:
             {"dataset_name": "flag", "score": True},  # bool is not a score
             {"dataset_name": "aime", "score": 80.0},
         ]
-        assert average_accuracy(scores) == 80.0
+        assert samples_weighted_average_accuracy(scores) == 80.0
 
     def test_homogeneous_fraction_scores_average(self):
         scores = [
             {"dataset_name": "aime", "score": 0.8},
             {"dataset_name": "gpqa", "score": 0.9},
         ]
-        assert average_accuracy(scores) == pytest.approx(0.85)
+        assert samples_weighted_average_accuracy(scores) == pytest.approx(0.85)
 
     def test_all_percentage_scores_average_incl_near_zero(self):
         # A percentage-scale set with a near-zero component must still average —
@@ -136,7 +243,7 @@ class TestAverageAccuracy:
             {"dataset_name": "lcb", "score": 0.0},
             {"dataset_name": "aime", "score": 80.0},
         ]
-        assert average_accuracy(scores) == pytest.approx(40.0)
+        assert samples_weighted_average_accuracy(scores) == pytest.approx(40.0)
 
     def test_excludes_by_type_not_name(self):
         # A dataset legitimately named "performance" but of accuracy type is still
@@ -144,12 +251,12 @@ class TestAverageAccuracy:
         scores = [
             {"dataset_name": "performance", "score": 90.0, "dataset_type": "accuracy"}
         ]
-        assert average_accuracy(scores) == 90.0
+        assert samples_weighted_average_accuracy(scores) == 90.0
 
     def test_none_when_nothing_numeric(self):
-        assert average_accuracy([]) is None
+        assert samples_weighted_average_accuracy([]) is None
         assert (
-            average_accuracy(
+            samples_weighted_average_accuracy(
                 [{"dataset_name": "perf", "score": 5.0, "dataset_type": "performance"}]
             )
             is None

--- a/tests/unit/metrics/test_results_plots.py
+++ b/tests/unit/metrics/test_results_plots.py
@@ -135,12 +135,29 @@ def test_extract_accuracy_non_bfcl_breakdown_falls_back_to_overall():
 @pytest.mark.unit
 def test_extract_accuracy_scalar_fallback_when_no_breakdown():
     """gpt-oss runs three single-metric datasets with no breakdown; without the
-    scalar fallback the plot is empty. One bar per dataset, overall = mean."""
+    scalar fallback the plot is empty. One bar per dataset; overall is the
+    unit_samples-weighted mean (matching accuracy_results.json average_accuracy),
+    NOT a flat mean and NOT weighted by total_samples (issued attempts)."""
     results = {
         "accuracy_scores": [
-            {"dataset_name": "aime25::gptoss", "score": 0.8, "total_samples": 30},
-            {"dataset_name": "gpqa::gptoss", "score": 0.9, "total_samples": 198},
-            {"dataset_name": "lcb::gptoss", "score": 0.7, "total_samples": 100},
+            {
+                "dataset_name": "aime25::gptoss",
+                "score": 0.8,
+                "unit_samples": 30,
+                "total_samples": 240,
+            },
+            {
+                "dataset_name": "gpqa::gptoss",
+                "score": 0.9,
+                "unit_samples": 198,
+                "total_samples": 990,
+            },
+            {
+                "dataset_name": "lcb::gptoss",
+                "score": 0.7,
+                "unit_samples": 100,
+                "total_samples": 300,
+            },
             {
                 "dataset_name": "perf",
                 "score": 0.0,
@@ -156,8 +173,34 @@ def test_extract_accuracy_scalar_fallback_when_no_breakdown():
         "gpqa::gptoss": pytest.approx(90.0),
         "lcb::gptoss": pytest.approx(70.0),
     }
-    assert b.overall == pytest.approx((80.0 + 90.0 + 70.0) / 3)
-    assert b.total_samples == 328  # perf entry excluded
+    # Weighted by unit_samples (30/198/100) -> ~82.99, distinct from the flat mean
+    # (80.0) and from a total_samples weighting (~84.5).
+    weighted = (0.8 * 30 + 0.9 * 198 + 0.7 * 100) / (30 + 198 + 100) * 100
+    assert b.overall == pytest.approx(weighted)
+    assert b.overall != pytest.approx((80.0 + 90.0 + 70.0) / 3)
+    assert b.total_samples == 1530  # sum of total_samples; perf entry excluded
+
+
+@pytest.mark.unit
+def test_extract_accuracy_scalar_fallback_bar_and_overall_stay_consistent():
+    """A rendered bar must always be included in the weighted overall — a
+    present-but-corrupt unit_samples contributes weight 1.0, never gets dropped
+    from the headline (which would make bars and overall disagree)."""
+    results = {
+        "accuracy_scores": [
+            {"dataset_name": "aime", "score": 0.8, "unit_samples": 30},
+            # Corrupt weight: still a valid score, so it renders a bar and must
+            # count toward overall at weight 1.0.
+            {"dataset_name": "bad", "score": 0.6, "unit_samples": "oops"},
+        ]
+    }
+    b = extract_accuracy(results)
+    assert b is not None
+    # Both datasets appear as bars...
+    assert set(b.subset_scores) == {"aime", "bad"}
+    # ...and both contribute to overall (30-weighted + 1.0-weighted), so it is not
+    # just the well-weighted bar (80.0) nor a flat mean (70.0).
+    assert b.overall == pytest.approx((80.0 * 30 + 60.0 * 1.0) / (30 + 1.0))
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The combined gpt-oss-120b accuracy was an unweighted mean of the three per-dataset scores (aime25/gpqa/livecodebench). That over-weights small datasets (AIME's 30 problems counted equally with LiveCodeBench's 1055) and diverges from the MLCommons reference submission score. Switch to a unique-problem-count weighted mean:

    overall = sum(score_d * unit_samples_d) / sum(unit_samples_d)

which reproduces the reference exact_match (83.374 vs the old 80.95 on the same run). Rename the aggregator to samples_weighted_average_accuracy; the accuracy_results.json key stays "average_accuracy" for consumer stability.

Also fix the gpt-oss accuracy plot (results_plots.py), which still computed an unweighted overall and would otherwise disagree with the report/JSON headline.

- Single-dataset models (DeepSeek-R1, BFCL, ...) are unchanged (weight cancels).
- Weight guard: absent/None unit_samples -> 1.0 (legacy artifacts); a present but non-positive/non-numeric weight is treated as corrupt and skipped.
- Tests: MLPerf reference lock (83.374), plot weighting, guard branches, and the average_accuracy JSON-key contract.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [ ] Tests added/updated
- [ ] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
