### PR TITLE
feat(load-generator): shuffle agentic conversation start order

### DIFF
--- a/docs/config/DESIGN.md
+++ b/docs/config/DESIGN.md
@@ -146,9 +146,9 @@ has not fully delegated runtime construction to rulesets yet.
 **Reproducibility via explicit seeds**
 
 `RuntimeSettings` contains two seeded `Random` instances: one for scheduler timing jitter
-(`rng_sched`) and one for dataset sample ordering (`rng_sample_index`). These make the runtime
-configuration reproducible in principle, but the original seed values are not currently persisted
-to the report output.
+(`rng_sched`) and one for dataset sample ordering (`rng_sample_index`, including agentic
+conversation start order). These make the runtime configuration reproducible in principle, but
+the original seed values are not currently persisted to the report output.
 
 ## Integration Points
 

--- a/docs/load_generator/DESIGN.md
+++ b/docs/load_generator/DESIGN.md
@@ -491,7 +491,10 @@ gates the _timing_ of the next turn, it does not alter its prompt. Concurrency i
 **active conversations** (`_target_concurrency`), not in-flight requests.
 
 - `execute(phase_issuer)` seeds up to `_target_concurrency` initial conversations, then awaits
-  completion of all of them.
+  completion of all of them. Conversation start order is a `WithoutReplacementSampleOrder` over
+  conversation indices when `rng_sample_index` is set (`dataloader_random_seed`, same RNG as
+  non-agentic sample shuffle); intra-conversation turn order is unchanged. Without an RNG,
+  conversations start in dataset encounter order.
 - On each response, `on_sample_complete(result)` synchronously routes it to its conversation and
   calls `_issue_next_turn()` → `_issue_turn_now()`, which stores the new `query_id → conversation_id`
   mapping and issues the turn with zero event-loop delay (or an optional per-turn delay). When a

--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -754,11 +754,15 @@ def _build_agentic_strategy(
         if perf_ds_cfg is not None:
             agentic_cfg = perf_ds_cfg.agentic_inference
     assert ctx.dataloader.conversation_metadata is not None
+    rng_sample_index = (
+        ctx.rt_settings.rng_sample_index if ctx.rt_settings is not None else None
+    )
     return AgenticInferenceStrategy(
         conversation_manager=ConversationManager(),
         dataset_metadata=ctx.dataloader.conversation_metadata,
         agentic_inference_config=agentic_cfg,
         target_concurrency=ctx.config.settings.load_pattern.target_concurrency,
+        rng_sample_index=rng_sample_index,
     )
 
 

--- a/src/inference_endpoint/config/runtime_settings.py
+++ b/src/inference_endpoint/config/runtime_settings.py
@@ -110,7 +110,7 @@ class RuntimeSettings:
     """Random number generator for scheduler"""
 
     rng_sample_index: random.Random
-    """Random number generator for sample indexing"""
+    """Random number generator for sample indexing / agentic conversation shuffle"""
 
     load_pattern: LoadPattern | None
     """Load pattern configuration"""

--- a/src/inference_endpoint/config/schema.py
+++ b/src/inference_endpoint/config/schema.py
@@ -635,7 +635,12 @@ class RuntimeConfig(BaseModel):
         cyclopts.Parameter(alias="--num-samples", help="Sample count override"),
     ] = Field(None, gt=0)
     scheduler_random_seed: int = Field(42, description="Scheduler RNG seed")
-    dataloader_random_seed: int = Field(42, description="Dataloader RNG seed")
+    dataloader_random_seed: int = Field(
+        42,
+        description=(
+            "Dataloader RNG seed (sample shuffle; agentic conversation order)"
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_durations(self) -> Self:

--- a/src/inference_endpoint/config/templates/concurrency_template_full.yaml
+++ b/src/inference_endpoint/config/templates/concurrency_template_full.yaml
@@ -55,7 +55,7 @@ settings:
     max_issue_duration_ms: null  # Cap on performance-phase issuing in ms; reaching it ends the phase normally (None = no cap)
     n_samples_to_issue: null  # Sample count override
     scheduler_random_seed: 42  # Scheduler RNG seed
-    dataloader_random_seed: 42  # Dataloader RNG seed
+    dataloader_random_seed: 42  # Dataloader RNG seed (sample shuffle; agentic conversation order)
   load_pattern:
     type: concurrency  # Load pattern type | options: max_throughput, poisson, concurrency, agentic_inference, burst, step
     target_qps: null  # Target QPS

--- a/src/inference_endpoint/config/templates/offline_template_full.yaml
+++ b/src/inference_endpoint/config/templates/offline_template_full.yaml
@@ -55,7 +55,7 @@ settings:
     max_issue_duration_ms: null  # Cap on performance-phase issuing in ms; reaching it ends the phase normally (None = no cap)
     n_samples_to_issue: null  # Sample count override
     scheduler_random_seed: 42  # Scheduler RNG seed
-    dataloader_random_seed: 42  # Dataloader RNG seed
+    dataloader_random_seed: 42  # Dataloader RNG seed (sample shuffle; agentic conversation order)
   load_pattern:
     type: max_throughput  # Load pattern type | offline only: max_throughput
     target_qps: null  # Target QPS

--- a/src/inference_endpoint/config/templates/online_template_full.yaml
+++ b/src/inference_endpoint/config/templates/online_template_full.yaml
@@ -55,7 +55,7 @@ settings:
     max_issue_duration_ms: null  # Cap on performance-phase issuing in ms; reaching it ends the phase normally (None = no cap)
     n_samples_to_issue: null  # Sample count override
     scheduler_random_seed: 42  # Scheduler RNG seed
-    dataloader_random_seed: 42  # Dataloader RNG seed
+    dataloader_random_seed: 42  # Dataloader RNG seed (sample shuffle; agentic conversation order)
   load_pattern:
     type: poisson  # Load pattern type | options: max_throughput, poisson, concurrency, agentic_inference, burst, step
     target_qps: 10.0  # Target QPS

--- a/src/inference_endpoint/load_generator/agentic_inference_strategy.py
+++ b/src/inference_endpoint/load_generator/agentic_inference_strategy.py
@@ -18,6 +18,7 @@
 import asyncio
 import hashlib
 import logging
+import random
 import time
 from collections import defaultdict
 from typing import Any
@@ -28,6 +29,11 @@ from ..core.types import ErrorData, QueryResult
 from ..dataset_manager.agentic_inference_dataset import ConversationMetadata
 from ..exceptions import InputValidationError
 from .conversation_manager import ConversationManager
+from .sample_order import (
+    SampleOrder,
+    SequentialSampleOrder,
+    WithoutReplacementSampleOrder,
+)
 from .strategy import PhaseIssuerProtocol
 
 logger = logging.getLogger(__name__)
@@ -45,10 +51,14 @@ class AgenticInferenceStrategy:
     """Event-driven agentic inference strategy. Completion of each turn triggers the next.
 
     execute() seeds the first N conversations (issues turn 1 for each), then
-    awaits _all_done. on_sample_complete() is called synchronously from the
-    receive coroutine for each response — it issues the next turn immediately
-    (zero event-loop iterations between response and next issuance), or starts
-    a new conversation when the current one finishes all turns.
+    awaits _all_done. Conversation start order uses the same without-replacement
+    shuffle as non-agentic datasets when rng_sample_index is provided
+    (RuntimeSettings.rng_sample_index / dataloader_random_seed); turns inside a
+    conversation stay in dataset order. on_sample_complete() is called
+    synchronously from the receive coroutine for each response — it issues the
+    next turn immediately (zero event-loop iterations between response and next
+    issuance), or starts a new conversation when the current one finishes all
+    turns.
 
     At most target_concurrency conversations are active simultaneously. When
     target_concurrency is None, all conversations start at once.
@@ -76,6 +86,7 @@ class AgenticInferenceStrategy:
         dataset_metadata: ConversationMetadata,
         agentic_inference_config: AgenticInferenceConfig | None = None,
         target_concurrency: int | None = None,
+        rng_sample_index: random.Random | None = None,
     ):
         """Initialize agentic inference strategy.
 
@@ -85,6 +96,9 @@ class AgenticInferenceStrategy:
             agentic_inference_config: Agentic inference conversation configuration.
             target_concurrency: Maximum number of simultaneously active conversations.
                 None means all conversations run concurrently.
+            rng_sample_index: Dataloader RNG used to shuffle conversation start
+                order (same seed as non-agentic WithoutReplacementSampleOrder).
+                None keeps dataset encounter order.
         """
         self._conv_manager = conversation_manager
         self._dataset_metadata = dataset_metadata
@@ -105,6 +119,7 @@ class AgenticInferenceStrategy:
             else _DEFAULT_TURN_TIMEOUT_S
         )
         self._target_concurrency = target_concurrency
+        self._rng_sample_index = rng_sample_index
         self._enable_salt = (
             agentic_inference_config.enable_salt
             if agentic_inference_config is not None
@@ -121,6 +136,7 @@ class AgenticInferenceStrategy:
 
         # Event-driven state — populated in execute().
         self._base_convs: list[tuple[str, ConversationTurns]] = []
+        self._conversation_order: SampleOrder | None = None
         self._active_iters: dict[str, ActiveConversationState] = {}
         self._timeout_handles: dict[str, asyncio.TimerHandle] = {}
         self._delay_handles: dict[str, asyncio.TimerHandle] = {}
@@ -161,6 +177,7 @@ class AgenticInferenceStrategy:
             (conv_id, sorted(turns, key=lambda x: x[1]))
             for conv_id, turns in conv_samples.items()
         ]
+        self._conversation_order = self._make_conversation_order()
         self._validate_salt_system_prompts()
         n_to_start = self._initial_conversations_to_start()
         try:
@@ -210,12 +227,39 @@ class AgenticInferenceStrategy:
     def _has_more_conversation_instances(self) -> bool:
         return bool(self._base_convs and self._has_trajectory_budget())
 
+    def _make_conversation_order(self) -> SampleOrder | None:
+        """Conversation-index iterator; shuffle when a dataloader RNG is set.
+
+        Only permutation orders are valid here. `_next_conversation_instance`
+        derives `repeat_id` as `started_count // n_convs + 1`, which assumes the
+        order yields each conversation index exactly once per block of `n_convs`
+        draws. `WithoutReplacementSampleOrder` and `SequentialSampleOrder` both
+        satisfy this. Do NOT swap in `WithReplacementSampleOrder` (or any order
+        that can repeat an index within a block) without first reworking
+        `repeat_id`: a conversation recurring within a block collides on
+        `(source_id, repeat_id)`, which duplicates the anti-cache salt (server
+        prefix-cache hits corrupt throughput) and the `logical_id` key in
+        `_active_iters` (conversation tracking overwrites).
+        """
+        n_convs = len(self._base_convs)
+        if n_convs == 0:
+            return None
+        if self._rng_sample_index is not None:
+            return WithoutReplacementSampleOrder(
+                n_samples_in_dataset=n_convs,
+                rng=self._rng_sample_index,
+            )
+        return SequentialSampleOrder(n_samples_in_dataset=n_convs)
+
     def _next_conversation_instance(self) -> ConversationInstance | None:
         if not self._has_more_conversation_instances():
             return None
 
-        source_index = self._started_trajectory_count % len(self._base_convs)
+        assert self._conversation_order is not None
+        source_index = next(self._conversation_order)
         source_id, turns = self._base_convs[source_index]
+        # Unique (source_id, repeat_id) relies on _conversation_order being a
+        # permutation every n_convs draws (see _make_conversation_order).
         instance_id = self._started_trajectory_count // len(self._base_convs) + 1
         logical_id = (
             source_id if instance_id == 1 else f"{source_id}__repeat_{instance_id}"
@@ -396,7 +440,7 @@ class AgenticInferenceStrategy:
                     conversation_id.encode("utf-8"), digest_size=2
                 ).hexdigest()
                 message["content"] = (
-                    f"[salt: {repeat_salt}]\n\n" f"{content}\n\n" f"[salt: {conv_salt}]"
+                    f"[salt: {repeat_salt}]\n\n{content}\n\n[salt: {conv_salt}]"
                 )
                 return salted_messages
         raise InputValidationError(

--- a/tests/unit/load_generator/test_agentic_inference_strategy.py
+++ b/tests/unit/load_generator/test_agentic_inference_strategy.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import hashlib
+import random
 from unittest.mock import MagicMock
 
 import pytest
@@ -151,6 +152,48 @@ def _make_dataset_metadata(conversations: dict[str, list[int]]) -> ConversationM
         max_turns_per_conv=max((max(t) for t in conversations.values()), default=0),
         client_turns_per_conversation={c: len(t) for c, t in conversations.items()},
     )
+
+
+def _source_conversation_id(logical_id: str) -> str:
+    marker = "__repeat_"
+    if marker in logical_id:
+        return logical_id.split(marker, 1)[0]
+    return logical_id
+
+
+def _trajectory_start_order(issuer: RecordingPhaseIssuer) -> list[str]:
+    starts: list[str] = []
+    seen: set[str] = set()
+    for _qid, _idx, conv, _turn, _override in issuer.records:
+        if conv in seen:
+            continue
+        seen.add(conv)
+        starts.append(conv)
+    return starts
+
+
+async def _drain_recording_strategy(
+    strategy: AgenticInferenceStrategy,
+    issuer: RecordingPhaseIssuer,
+) -> int:
+    execute_task = asyncio.create_task(strategy.execute(issuer))
+    completed: set[str] = set()
+
+    async def _pump() -> int:
+        while not execute_task.done():
+            await asyncio.sleep(0)
+            for query_id, *_rest in issuer.records:
+                if query_id in completed:
+                    continue
+                strategy.on_sample_complete(
+                    QueryResult(
+                        id=query_id, response_output=TextModelOutput(output="ok")
+                    )
+                )
+                completed.add(query_id)
+        return await execute_task
+
+    return await asyncio.wait_for(_pump(), timeout=2.0)
 
 
 @pytest.mark.unit
@@ -306,10 +349,10 @@ async def test_salted_turns_use_repeat_and_conversation_salts():
     repeat2_salt = hashlib.blake2b(b"2", digest_size=2).hexdigest()
     conversation_salt = hashlib.blake2b(b"conv1", digest_size=2).hexdigest()
     assert first_system == (
-        f"[salt: {repeat1_salt}]\n\n" f"Be helpful\n\n" f"[salt: {conversation_salt}]"
+        f"[salt: {repeat1_salt}]\n\nBe helpful\n\n[salt: {conversation_salt}]"
     )
     assert repeat_system == (
-        f"[salt: {repeat2_salt}]\n\n" f"Be helpful\n\n" f"[salt: {conversation_salt}]"
+        f"[salt: {repeat2_salt}]\n\nBe helpful\n\n[salt: {conversation_salt}]"
     )
     assert repeat_system != base_messages[0]["content"]
     assert base_messages[0]["content"] == "Be helpful"
@@ -1103,3 +1146,198 @@ async def test_inject_tool_delay_cancels_on_timeout():
         0,
         1,
     ], f"turn 3 should not have been issued after timeout; issued={issuer.issued}"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conversation_order_without_rng_follows_dataset_order():
+    conv_ids = [f"conv{i}" for i in range(8)]
+    metadata = _make_dataset_metadata({cid: [1] for cid in conv_ids})
+    strategy = AgenticInferenceStrategy(
+        ConversationManager(), metadata, target_concurrency=None
+    )
+    issuer = RecordingPhaseIssuer()
+    await _drain_recording_strategy(strategy, issuer)
+    assert _trajectory_start_order(issuer) == conv_ids
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conversation_shuffle_matches_without_replacement_sample_order():
+    conv_ids = [f"conv{i}" for i in range(8)]
+    metadata = _make_dataset_metadata({cid: [1] for cid in conv_ids})
+    strategy = AgenticInferenceStrategy(
+        ConversationManager(),
+        metadata,
+        target_concurrency=None,
+        rng_sample_index=random.Random(42),
+    )
+    issuer = RecordingPhaseIssuer()
+    await _drain_recording_strategy(strategy, issuer)
+
+    expected_indices = list(range(8))
+    random.Random(42).shuffle(expected_indices)
+    assert expected_indices != list(range(8))
+    assert _trajectory_start_order(issuer) == [conv_ids[i] for i in expected_indices]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conversation_shuffle_is_reproducible():
+    conv_ids = [f"conv{i}" for i in range(8)]
+    metadata = _make_dataset_metadata({cid: [1] for cid in conv_ids})
+
+    async def run(seed: int) -> list[str]:
+        strategy = AgenticInferenceStrategy(
+            ConversationManager(),
+            metadata,
+            target_concurrency=None,
+            rng_sample_index=random.Random(seed),
+        )
+        issuer = RecordingPhaseIssuer()
+        await _drain_recording_strategy(strategy, issuer)
+        return _trajectory_start_order(issuer)
+
+    first = await run(42)
+    second = await run(42)
+    other = await run(99)
+    assert first == second
+    assert first != other
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conversation_shuffle_preserves_turn_order_within_conversation():
+    conv_ids = [f"conv{i}" for i in range(8)]
+    metadata = _make_dataset_metadata({cid: [1, 2] for cid in conv_ids})
+    strategy = AgenticInferenceStrategy(
+        ConversationManager(),
+        metadata,
+        target_concurrency=None,
+        rng_sample_index=random.Random(42),
+    )
+    issuer = RecordingPhaseIssuer()
+    await _drain_recording_strategy(strategy, issuer)
+
+    turns_by_conv: dict[str, list[int]] = {}
+    for _qid, _idx, conv, turn, _override in issuer.records:
+        assert turn is not None
+        turns_by_conv.setdefault(conv, []).append(turn)
+    assert len(turns_by_conv) == 8
+    for turns in turns_by_conv.values():
+        assert turns == [1, 2]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conversation_shuffle_reshuffles_each_pass():
+    conv_ids = [f"conv{i}" for i in range(8)]
+    metadata = _make_dataset_metadata({cid: [1] for cid in conv_ids})
+    cfg = AgenticInferenceConfig(num_trajectories_to_issue=16)
+    strategy = AgenticInferenceStrategy(
+        ConversationManager(),
+        metadata,
+        agentic_inference_config=cfg,
+        target_concurrency=None,
+        rng_sample_index=random.Random(42),
+    )
+    issuer = RecordingPhaseIssuer()
+    await _drain_recording_strategy(strategy, issuer)
+
+    starts = [
+        _source_conversation_id(logical_id)
+        for logical_id in _trajectory_start_order(issuer)
+    ]
+    first_pass, second_pass = starts[:8], starts[8:]
+    assert sorted(first_pass) == conv_ids
+    assert sorted(second_pass) == conv_ids
+    assert first_pass != second_pass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conversation_shuffle_honored_under_bounded_concurrency():
+    """Bounded concurrency draws from the same seeded shuffle as start-all-at-once.
+
+    The production path uses a finite ``target_concurrency`` (e.g. 8), so the
+    shuffle is advanced from ``_fill_slot`` on completion rather than the
+    ``execute()`` seed loop. Start order must still equal the seeded
+    without-replacement permutation and be independent of the concurrency cap.
+    """
+    conv_ids = [f"conv{i}" for i in range(8)]
+    metadata = _make_dataset_metadata({cid: [1] for cid in conv_ids})
+
+    async def start_order(target_concurrency: int | None) -> list[str]:
+        strategy = AgenticInferenceStrategy(
+            ConversationManager(),
+            metadata,
+            target_concurrency=target_concurrency,
+            rng_sample_index=random.Random(42),
+        )
+        issuer = RecordingPhaseIssuer()
+        await _drain_recording_strategy(strategy, issuer)
+        return _trajectory_start_order(issuer)
+
+    expected_indices = list(range(8))
+    random.Random(42).shuffle(expected_indices)
+    expected = [conv_ids[i] for i in expected_indices]
+
+    bounded = await start_order(2)
+    unbounded = await start_order(None)
+    assert bounded == expected
+    assert bounded == unbounded
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_salt_is_unique_across_shuffled_conversations_and_repeats():
+    """Salted prompts stay unique when shuffle and salting are both on.
+
+    Every conversation shares identical base content, so only the
+    ``(repeat_id, conversation_id)`` salt can distinguish issued prompts. With a
+    shuffled start order over two passes, all issued prompts must be distinct
+    (anti-cache), and the same conversation's two passes must differ because
+    ``repeat_id`` changes the salt.
+    """
+    conv_ids = [f"conv{i}" for i in range(4)]
+    metadata = _make_dataset_metadata({cid: [1] for cid in conv_ids})
+    base_messages = [
+        {"role": "system", "content": "Be helpful"},
+        {"role": "user", "content": "hello"},
+    ]
+    metadata.pre_built_messages_by_key = {(cid, 1): base_messages for cid in conv_ids}
+    cfg = AgenticInferenceConfig(enable_salt=True, num_trajectories_to_issue=8)
+    strategy = AgenticInferenceStrategy(
+        ConversationManager(),
+        metadata,
+        agentic_inference_config=cfg,
+        target_concurrency=None,
+        rng_sample_index=random.Random(42),
+    )
+    issuer = RecordingPhaseIssuer()
+    await _drain_recording_strategy(strategy, issuer)
+
+    def _system_salt(override: dict | None) -> str:
+        assert override is not None
+        system = next(m for m in override["messages"] if m["role"] == "system")
+        content = system["content"]
+        assert content.startswith("[salt: ")
+        return content
+
+    salted = [_system_salt(record[4]) for record in issuer.records]
+    assert len(salted) == 8
+    # Anti-cache: identical base content, yet every issued prompt is distinct.
+    assert len(set(salted)) == 8
+
+    # repeat_id changes the salt: each conversation's two passes differ.
+    salts_by_source: dict[str, list[str]] = {}
+    for content, (_q, _idx, logical_id, _turn, _override) in zip(
+        salted, issuer.records, strict=False
+    ):
+        salts_by_source.setdefault(_source_conversation_id(logical_id), []).append(
+            content
+        )
+    assert len(salts_by_source) == 4
+    for source_id, salts in salts_by_source.items():
+        assert len(salts) == 2, source_id
+        assert salts[0] != salts[1], source_id


### PR DESCRIPTION
## What does this PR do?

Shuffles agentic conversation **start order** using a seeded without-replacement
permutation over conversation indices, matching the default every other perf workload
already uses (agentic previously ran in dataset encounter order). Intra-conversation turn
order is unchanged; ordering is deterministic via `dataloader_random_seed` (default 42).
Note: agentic perf results are no longer bit-comparable to pre-change runs, with no opt-out
to restore encounter order.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/cleanup

## Related issues

<!-- Link any related issues: Closes #123 -->

## Testing

- [X] Tests added/updated
- [X] All tests pass locally
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project style
- [ ] Pre-commit hooks pass
- [ ] Documentation updated (if needed)
