### PR TITLE
feat(metrics): full-run OSL over all agentic turns for accuracy validation

### DIFF
--- a/examples/10_Agentic_Inference/README.md
+++ b/examples/10_Agentic_Inference/README.md
@@ -115,6 +115,8 @@ The benchmark stops performance tracking when the first active user finishes its
 
 For official submissions, submitters must set `agentic_inference.stop_issuing_on_first_user_complete` to `false` so the client finishes already-started trajectories for accuracy. During optimization, set it to `true` to stop issuing future turns at the performance boundary and shorten the tail.
 
+> **OSL for the accuracy gate.** Because tail turns are excluded from performance metrics, the windowed `output_sequence_lengths.avg` in `performance/result_summary.json` is concurrency-dependent and must **not** be used for the OSL accuracy requirement. Use `output_sequence_lengths_full_run.output_sequence_lengths.avg` — the per-turn mean over **all** turns (tail and dataset repeats included), computed with the same token-counting rule as the window, which is invariant to concurrency. A run is not valid for the OSL accuracy check when `output_sequence_lengths_full_run` is `null`, **or** its `n_turns_counted` is `0` (turns were scanned but none were countable), **or** the report is not `complete`. `report.txt` prints it as `OSL per-turn mean (accuracy, all turns)`.
+
 ### SWE-bench Accuracy
 
 Submitters must enable SWE-bench accuracy for official submissions. The Kimi K3, Qwen3.6-35B-A3B, and DSV4 example YAML files include the required SWE-bench accuracy dataset. The benchmark framework skips its built-in endpoint phase for the SWE-bench dataset. Instead, `SWEBenchScorer` submits the run to a native SWE-bench service. The service host owns Docker, `mini-swe-agent`, and the `swebench` evaluation harness, and it drives requests to the configured endpoint.
@@ -252,8 +254,10 @@ Reference mean values are shown in parentheses.
 | Metric             |               Kimi K3 |        Qwen3.6-35B-A3B | DSV4 |
 | ------------------ | --------------------: | ---------------------: | ---: |
 | Inline accuracy    | `>= 58.32%` (`58.9%`) | `>= 55.86%` (`56.43%`) |  TBD |
-| OSL per-turn mean  |      `390-475` tokens |       `355-434` tokens |  TBD |
+| OSL per-turn mean¹ |      `390-475` tokens |       `355-434` tokens |  TBD |
 | SWE-bench accuracy | `>= 93.5%` (`94.83%`) |     `>= 69%` (`71.7%`) |  TBD |
+
+¹ Read from `output_sequence_lengths_full_run.output_sequence_lengths.avg` (the full-run, all-turns mean), **not** the windowed `output_sequence_lengths.avg`. See [Tail Management](#tail-management).
 
 ### Approved Checkpoints and Speculative-Decoding Heads
 

--- a/src/inference_endpoint/async_utils/services/metrics_aggregator/metrics_table.py
+++ b/src/inference_endpoint/async_utils/services/metrics_aggregator/metrics_table.py
@@ -31,6 +31,7 @@ from inference_endpoint.async_utils.services.metrics_aggregator.tokenization imp
     TextInput,
     TokenIdsInput,
     TokenizationInput,
+    extract_tokenization_input,
 )
 from inference_endpoint.core.record import SampleEventType, SessionEventType
 from inference_endpoint.core.types import PromptData, TextModelOutput
@@ -346,12 +347,7 @@ class OslTrigger(TokenTrigger):
     def _extract_tokenization_input(self, ev_rec, row, pre_change):
         if not isinstance(ev_rec.data, TextModelOutput):
             return None
-        if ev_rec.data.reasoning or ev_rec.data.tool_calls:
-            return MessageInput(*ev_rec.data.as_message_parts())
-        text = str(ev_rec.data)
-        if text:
-            return TextInput(text)
-        return None
+        return extract_tokenization_input(ev_rec.data)
 
 
 class TpotTrigger(TokenTrigger):

--- a/src/inference_endpoint/async_utils/services/metrics_aggregator/token_metrics.py
+++ b/src/inference_endpoint/async_utils/services/metrics_aggregator/token_metrics.py
@@ -566,6 +566,40 @@ class BatchTokenizer:
             for (index, _), count in zip(indexed_texts, counts, strict=True)
         ]
 
+    def count_sync(self, item: TokenizationInput) -> int:
+        """Count one input on the calling thread.
+
+        The post-run counterpart to :meth:`count_batch_async`, for callers that
+        run after the event loop is gone (full-run OSL at finalize). Dispatch
+        mirrors ``count_batch_async`` exactly — same text backend, same chat
+        template, same baseline subtraction — so a turn counted here and a turn
+        counted on the perf hot path yield the same number. Divergence between
+        the two lanes would make the windowed and full-run OSL statistics
+        incomparable (mlcommons/endpoints#500).
+        """
+        match item:
+            case TokenIdsInput(token_ids=token_ids):
+                return len(token_ids)
+            case TextInput(text=text):
+                return self._encode_lengths_inproc([text])[0]
+            case MessageInput(content, reasoning, tool_calls):
+                return self._token_count_message(content, reasoning, tool_calls)
+            case PromptInput(
+                messages,
+                tools,
+                chat_template_kwargs,
+                chat_template,
+                tool_choice,
+            ):
+                return self._token_count_prompt(
+                    messages,
+                    tools,
+                    chat_template_kwargs,
+                    chat_template,
+                    tool_choice,
+                )
+        raise TypeError(f"unsupported tokenization input: {type(item).__name__}")
+
     async def count_batch_async(
         self,
         inputs: list[TokenizationInput],
@@ -641,8 +675,15 @@ class BatchTokenizer:
         drops queued encodes (``cancel_futures``); only a single in-flight
         encode (bounded by ``_LIVE_FLUSH_MAX_ITEMS``) is waited on.
         """
-        _terminate_procs(self._procs)
-        self._procs = []
+        # Only walk/terminate when this tokenizer owns shard workers.
+        # _terminate_procs walks multiprocessing.active_children() to catch a
+        # shard hung in its initializer; that set is shard-only in the aggregator
+        # subprocess, but in a non-aggregator host (e.g. the finalize-side
+        # in-process tokenizer, n_workers=0, which never creates shards) it would
+        # be unrelated processes such as the HTTP workers. Skip it when we own none.
+        if self._procs:
+            _terminate_procs(self._procs)
+            self._procs = []
         if self._thread is not None:
             self._thread.shutdown(wait=True, cancel_futures=True)
             self._thread = None

--- a/src/inference_endpoint/async_utils/services/metrics_aggregator/tokenization.py
+++ b/src/inference_endpoint/async_utils/services/metrics_aggregator/tokenization.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, TypeAlias
 
+from inference_endpoint.core.types import TextModelOutput
+
 
 @dataclass(frozen=True, slots=True)
 class TokenIdsInput:
@@ -51,3 +53,26 @@ class PromptInput:
 TokenizationInput: TypeAlias = (  # noqa: UP040 - mypy version lacks PEP 695.
     TokenIdsInput | TextInput | MessageInput | PromptInput
 )
+
+
+def extract_tokenization_input(
+    output: TextModelOutput,
+) -> MessageInput | TextInput | None:
+    """The OSL rule: how one model output is rendered for token counting.
+
+    Single source of truth for both OSL populations — the performance-window
+    series (``OslTrigger``) and the full-run statistic. Keeping one rule is
+    what makes the two numbers comparable; a second, text-only implementation
+    silently under-counts reasoning and tool calls (mlcommons/endpoints#500).
+
+    Returns ``None`` for an output that must not be counted at all: an empty
+    completion is excluded rather than counted as a zero-token sample, because
+    a failed request still logs a COMPLETE event with ``output == ""`` and
+    would otherwise drag ``min``/``avg`` down.
+    """
+    if output.reasoning or output.tool_calls:
+        return MessageInput(*output.as_message_parts())
+    text = str(output)
+    if text:
+        return TextInput(text)
+    return None

--- a/src/inference_endpoint/commands/benchmark/execute.py
+++ b/src/inference_endpoint/commands/benchmark/execute.py
@@ -56,6 +56,7 @@ from inference_endpoint.commands.benchmark.accuracy import (
     score_accuracy,
     write_accuracy_results,
 )
+from inference_endpoint.commands.benchmark.full_run_osl import full_run_osl_for_report
 from inference_endpoint.commands.benchmark.pipeline import MetricsPipeline
 from inference_endpoint.commands.benchmark.profiling import (
     ProfileController,
@@ -1192,13 +1193,18 @@ def finalize_benchmark(ctx: BenchmarkContext, bench: BenchmarkResult) -> None:
     # sample_idx_map.json + events.jsonl from here).
     _write_scoring_artifacts(ctx, result, bench.tmpfs_dir)
 
-    # Accuracy scoring runs before report writing so its headline can attach.
-    # The finally block still writes the performance report if scoring fails.
+    # Full-run OSL over every turn, including those issued after the performance
+    # window closed, plus accuracy scoring. Both run inside the try/finally so a
+    # Ctrl-C during the (large) event-log scan still writes an interrupted report
+    # instead of losing it. Skipped on abort: a partial tail would report as
+    # complete.
+    full_run_osl: dict[str, Any] | None = None
     accuracy_scores: list[dict[str, Any]] = []
     try:
         if aborted:
             logger.warning("Run aborted — skipping accuracy scoring on partial data")
         else:
+            full_run_osl = full_run_osl_for_report(ctx.report_dir, ctx.tokenizer_name)
             accuracy_scores = score_accuracy(ctx, result)
     except KeyboardInterrupt:
         if report is not None:
@@ -1211,7 +1217,11 @@ def finalize_benchmark(ctx: BenchmarkContext, bench: BenchmarkResult) -> None:
         # Attach the per-dataset accuracy list so result_summary.json, the
         # console summary, and report.txt all carry it.
         if report is not None:
-            final_report = msgspec.structs.replace(report, accuracy=accuracy_scores)
+            final_report = msgspec.structs.replace(
+                report,
+                accuracy=accuracy_scores,
+                output_sequence_lengths_full_run=full_run_osl,
+            )
             _write_report_artifacts(ctx, final_report, bench.profiling)
             report = final_report
     bench.report = report

--- a/src/inference_endpoint/commands/benchmark/full_run_osl.py
+++ b/src/inference_endpoint/commands/benchmark/full_run_osl.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Full-run OSL — output token lengths over every turn, including the tail.
+
+The performance window closes when the first user finishes its final assigned
+trajectory, and turns issued after that point never reach the metrics
+aggregator at all (they are dropped at row creation). The windowed OSL is
+therefore a concurrency-dependent subsample: at higher concurrency the window
+closes earlier, so a different — and systematically shorter — subset of turns
+is measured, even when the model produces identical output for every turn.
+
+This module recomputes OSL over every completed turn from ``events.jsonl``,
+which retains the full ``TextModelOutput`` (reasoning and tool calls included)
+regardless of tracking state. Counting goes through the same
+``extract_tokenization_input`` rule the perf-side ``OslTrigger`` uses, so the
+two statistics are comparable rather than merely adjacent.
+
+See mlcommons/endpoints#500.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Collection
+from pathlib import Path
+from typing import Any
+
+import msgspec
+
+from inference_endpoint.async_utils.services.metrics_aggregator.token_metrics import (
+    BatchTokenizer,
+)
+from inference_endpoint.async_utils.services.metrics_aggregator.tokenization import (
+    MessageInput,
+    TextInput,
+    extract_tokenization_input,
+)
+from inference_endpoint.core.record import EventRecord, EventType
+from inference_endpoint.core.types import TextModelOutput
+from inference_endpoint.metrics.report import series_metric_dict
+
+logger = logging.getLogger(__name__)
+
+# Matched against each line's leading bytes so the 6+ GB of prompt and response
+# payload in a large run is never decoded just to classify the record.
+_COMPLETE_MARKER = b'"event_type":"sample.complete"'
+_PREFIX_BYTES = 256
+# AgenticInferenceInlineScorer's dataset_name; the key its turns live under in
+# sample_idx_map.json.
+_PERFORMANCE_PHASE = "performance"
+
+TokenCounter = Callable[[MessageInput | TextInput], int]
+
+
+def _in_population(
+    record: EventRecord,
+    performance_uuids: Collection[str] | None,
+) -> bool:
+    """Whether one COMPLETE record belongs to the full-run OSL population.
+
+    This is the policy boundary for "all turns", and the one place to change
+    if that definition moves.
+
+    ``events.jsonl`` is written for the whole run, so it also holds the
+    accuracy phases' completions (SWE-bench). Bounding the population by the
+    performance phase's uuids from ``sample_idx_map.json`` keeps an accuracy
+    turn from inflating the performance statistic. ``None`` means "no bound",
+    used only when the caller has already narrowed the file.
+
+    Deliberately NOT filtered here:
+
+    - Tail turns issued after STOP_PERFORMANCE_TRACKING. Including them is the
+      entire point of this statistic.
+    - Salted turns (``agentic_inference.enable_salt``). Salt perturbs the
+      prompt to defeat prefix caching; it does not create extra turns, so
+      there is nothing to exclude.
+    - Empty completions. Those are excluded by ``extract_tokenization_input``
+      returning ``None`` — the same rule the perf side applies — and counted
+      under ``n_empty`` rather than dropped silently.
+    """
+    if performance_uuids is None:
+        return True
+    return record.sample_uuid in performance_uuids
+
+
+def compute_full_run_osl(
+    events_path: Path,
+    count_tokens: TokenCounter,
+    *,
+    performance_uuids: Collection[str] | None = None,
+) -> dict[str, Any] | None:
+    """Roll up OSL over every completed turn in ``events_path``.
+
+    Returns ``None`` only when the file held no relevant COMPLETE lines at all.
+    A file with records but nothing countable (all empty, timed out, errored, or
+    undecodable) returns a block with an empty ``output_sequence_lengths`` and
+    non-zero ``n_empty``/``n_errors``/``n_undecodable`` so the run stays visible
+    rather than looking uncomputed.
+    """
+    decoder = msgspec.json.Decoder(type=EventRecord, dec_hook=EventType.decode_hook)
+    lengths: list[int] = []
+    n_empty = 0
+    n_errors = 0
+    n_undecodable = 0
+    first_error: str | None = None
+
+    with events_path.open("rb") as events_file:
+        for line in events_file:
+            if _COMPLETE_MARKER not in line[:_PREFIX_BYTES]:
+                continue
+            # Decode before the population filter so a corrupt line — which we
+            # cannot attribute to the performance population — is skipped rather
+            # than charged to n_errors.
+            try:
+                record = decoder.decode(line)
+            except msgspec.DecodeError:
+                n_undecodable += 1
+                continue
+            if not _in_population(record, performance_uuids):
+                continue
+            if record.data is None:
+                n_empty += 1  # e.g. a timed-out turn logs COMPLETE with data=None
+                continue
+            if not isinstance(record.data, TextModelOutput):
+                # Unexpected payload (ErrorData/PromptData) on a COMPLETE event.
+                n_errors += 1
+                if first_error is None:
+                    first_error = f"unexpected {type(record.data).__name__} payload"
+                continue
+            # Output preparation stays inside the per-turn try: a malformed
+            # tool-call payload can raise in extract_tokenization_input, and one
+            # bad turn must not void the whole statistic.
+            try:
+                tokenization_input = extract_tokenization_input(record.data)
+                if tokenization_input is None:
+                    n_empty += 1
+                    continue
+                lengths.append(count_tokens(tokenization_input))
+            except Exception as e:  # noqa: BLE001 - one bad turn must not void the stat
+                n_errors += 1
+                if first_error is None:
+                    first_error = str(e)
+
+    # Warn once with the aggregate rather than once per turn, so a systematic
+    # failure (bad tokenizer, corrupt log) does not flood the finalize log.
+    if n_undecodable:
+        logger.warning(
+            "Full-run OSL: skipped %d undecodable COMPLETE line(s)", n_undecodable
+        )
+    if n_errors:
+        logger.warning(
+            "Full-run OSL: %d turn(s) could not be counted (first: %s)",
+            n_errors,
+            first_error,
+        )
+
+    if not lengths and not n_empty and not n_errors and not n_undecodable:
+        return None
+    return {
+        "output_sequence_lengths": series_metric_dict(lengths),
+        "n_turns_counted": len(lengths),
+        "n_empty": n_empty,
+        "n_errors": n_errors,
+        "n_undecodable": n_undecodable,
+    }
+
+
+def load_performance_uuids(report_dir: Path) -> set[str] | None:
+    """Sample uuids belonging to the performance phase.
+
+    ``sample_idx_map.json`` is keyed by dataset name; the agentic inline
+    scorer runs with ``dataset_name="performance"``. Every issued perf turn is
+    recorded there unconditionally at issue time, so it is a complete
+    enumeration of the population — tail turns included.
+
+    Returns ``None`` when the map is missing, unreadable, or carries no
+    performance phase. ``full_run_osl_for_report`` treats that as "skip the
+    block" (fail closed) so accuracy-phase turns can never be counted as
+    performance OSL; only a caller that has already narrowed the file to the
+    performance population may pass ``None`` to ``compute_full_run_osl`` as
+    "no further bound".
+    """
+    path = report_dir / "sample_idx_map.json"
+    if not path.is_file():
+        return None
+    try:
+        idx_map = msgspec.json.decode(path.read_bytes())
+    except (msgspec.DecodeError, OSError) as e:
+        logger.warning("Full-run OSL: unreadable sample_idx_map.json: %s", e)
+        return None
+    per_phase = idx_map.get(_PERFORMANCE_PHASE) if isinstance(idx_map, dict) else None
+    if not isinstance(per_phase, dict) or not per_phase:
+        return None
+    return set(per_phase)
+
+
+def full_run_osl_for_report(
+    report_dir: Path,
+    tokenizer_name: str | None,
+) -> dict[str, Any] | None:
+    """Compute the full-run OSL block for a finished run's report directory.
+
+    Best-effort by design: a tokenizer that cannot be loaded drops the block
+    rather than failing finalize. Counting runs in-process (``n_workers=0``),
+    which works with or without a fast (Rust) backend — the same fallback the
+    live ``OslTrigger`` uses — so the block is not gated on backend
+    availability. Returns ``None`` when there is no performance population to
+    bound to (accuracy-only / perf-less runs).
+    """
+    events_path = report_dir / "events.jsonl"
+    if tokenizer_name is None or not events_path.is_file():
+        return None
+    performance_uuids = load_performance_uuids(report_dir)
+    if performance_uuids is None:
+        # Fail closed: without the performance-phase uuid set we cannot bound the
+        # population to perf turns, and counting unbounded would fold accuracy-phase
+        # completions into the accuracy OSL. Absent only for accuracy-only / perf-less
+        # runs or an unreadable map.
+        logger.info("Full-run OSL skipped: no performance-phase samples to bound to")
+        return None
+    try:
+        with BatchTokenizer(tokenizer_name, live_workers=1, n_workers=0) as tokenizer:
+            return compute_full_run_osl(
+                events_path,
+                tokenizer.count_sync,
+                performance_uuids=performance_uuids,
+            )
+    except Exception as e:  # noqa: BLE001 - optional block; never fail finalize
+        logger.warning("Full-run OSL skipped: %s", e)
+        return None

--- a/src/inference_endpoint/metrics/report.py
+++ b/src/inference_endpoint/metrics/report.py
@@ -239,6 +239,19 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
     # scorers, a BFCL-shaped breakdown. Display-only.
     accuracy: list[dict[str, Any]] = msgspec.field(default_factory=list)
 
+    # OSL over EVERY completed turn, including turns issued after the
+    # performance window closed. ``output_sequence_lengths`` above covers only
+    # the window, whose length depends on concurrency — so it is not
+    # comparable across Pareto points, while this block is. Same token-counting
+    # rule (``extract_tokenization_input``) on both. Attached at finalize; None
+    # only when the block was skipped (no tokenizer, or an unreadable/missing
+    # performance sample map). A run that scanned turns but counted none returns
+    # a block with ``n_turns_counted == 0`` — so a run is invalid for the OSL
+    # accuracy gate when this is None OR ``n_turns_counted == 0`` OR not complete.
+    # Carries ``output_sequence_lengths``/``n_turns_counted``/``n_empty``/
+    # ``n_errors``/``n_undecodable``. See mlcommons/endpoints#500.
+    output_sequence_lengths_full_run: dict[str, Any] | None = None
+
     @property
     def n_samples_succeeded(self) -> int:
         return max(0, self.n_samples_completed - self.n_samples_failed)
@@ -529,6 +542,40 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
                 osl_tok = sum(e.get("osl_tokenize_s", 0.0) for e in self.accuracy)
                 fn(f"  OSL tokenization: {osl_tok:.3g}s{newline}")
 
+        fr = self.output_sequence_lengths_full_run
+        n_counted = (fr or {}).get("n_turns_counted", 0)
+        if fr and n_counted > 0:
+            osl = fr.get("output_sequence_lengths", {})
+            fn(
+                f"  OSL per-turn mean (accuracy, all turns): "
+                f"{osl.get('avg', 0):.1f} tokens over {n_counted} turns "
+                f"({fr.get('n_empty', 0)} empty, {fr.get('n_errors', 0)} errored, "
+                f"{fr.get('n_undecodable', 0)} undecodable){newline}"
+            )
+            if not self.complete:
+                fn(
+                    f"    (run incomplete — NOT valid for the OSL accuracy gate){newline}"
+                )
+        elif fr:
+            # Block present but no countable turns — do not print a fake 0.0 mean.
+            fn(
+                f"  OSL per-turn mean (accuracy): no countable turns "
+                f"({fr.get('n_empty', 0)} empty, {fr.get('n_errors', 0)} errored, "
+                f"{fr.get('n_undecodable', 0)} undecodable){newline}"
+            )
+        elif self.output_sequence_lengths and self.complete:
+            # A complete performance run (windowed OSL present) but no full-run
+            # block: the accuracy OSL field is missing, so the run is not usable
+            # for that gate.
+            fn(
+                f"  OSL per-turn mean (accuracy): not computed "
+                f"(no tokenizer or unreadable sample map){newline}"
+            )
+        elif not self.complete:
+            fn(
+                f"  OSL per-turn mean (accuracy): not computed — run incomplete{newline}"
+            )
+
         if summary_only:
             fn(f"----------------- End of Summary -----------------{newline}")
             return
@@ -540,7 +587,17 @@ class Report(msgspec.Struct, frozen=True):  # type: ignore[call-arg]
             ("TPOT", self.tpot, "ms", 1e-6),
             ("Latency", self.latency, "ms", 1e-6),
             ("Input sequence lengths", self.input_sequence_lengths, "tokens", 1.0),
+            # Label deliberately unchanged: existing tooling parses report.txt
+            # by section name. The full-run block is added alongside it.
             ("Output sequence lengths", self.output_sequence_lengths, "tokens", 1.0),
+            (
+                "Output sequence lengths (full run, all turns)",
+                (self.output_sequence_lengths_full_run or {}).get(
+                    "output_sequence_lengths", {}
+                ),
+                "tokens",
+                1.0,
+            ),
         ]:
             if not metric_dict:
                 continue

--- a/tests/unit/async_utils/services/metrics_aggregator/test_output_tokenization_rule.py
+++ b/tests/unit/async_utils/services/metrics_aggregator/test_output_tokenization_rule.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The single OSL population/rendering rule shared by every OSL consumer.
+
+The performance window and the full-run statistic must count tokens the same
+way, or the two numbers are not comparable (mlcommons/endpoints#500). These
+tests pin the rule itself, independent of either consumer.
+"""
+
+from __future__ import annotations
+
+import pytest
+from inference_endpoint.async_utils.services.metrics_aggregator.tokenization import (
+    MessageInput,
+    TextInput,
+    extract_tokenization_input,
+)
+from inference_endpoint.core.types import TextModelOutput
+
+pytestmark = pytest.mark.unit
+
+
+def test_tool_call_output_renders_via_chat_template() -> None:
+    """A tool-call output must select MessageInput, never flattened text.
+
+    Flattening loses the tool_calls structure, which is exactly how a
+    text-only counter under-counts an agentic turn.
+    """
+    output = TextModelOutput(
+        output="",
+        tool_calls=(
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "bash", "arguments": '{"command": "ls"}'},
+            },
+        ),
+    )
+
+    result = extract_tokenization_input(output)
+
+    assert isinstance(result, MessageInput)
+    assert result.tool_calls is not None
+
+
+def test_reasoning_output_renders_via_chat_template() -> None:
+    """Reasoning traces also require the chat-template path."""
+    output = TextModelOutput(output="answer", reasoning="thinking about it")
+
+    result = extract_tokenization_input(output)
+
+    assert isinstance(result, MessageInput)
+    assert result.reasoning == "thinking about it"
+
+
+def test_plain_text_output_uses_text_path() -> None:
+    """A plain output with no structure stays on the cheap text path."""
+    output = TextModelOutput(output="just text")
+
+    result = extract_tokenization_input(output)
+
+    assert isinstance(result, TextInput)
+    assert result.text == "just text"
+
+
+def test_empty_output_is_excluded() -> None:
+    """An empty completion is not a zero-token sample.
+
+    A failed request still logs a COMPLETE event with output == ""; counting
+    it as 0 would drag min/avg down on both the window and the full run.
+    """
+    assert extract_tokenization_input(TextModelOutput(output="")) is None

--- a/tests/unit/async_utils/services/metrics_aggregator/test_token_metrics.py
+++ b/tests/unit/async_utils/services/metrics_aggregator/test_token_metrics.py
@@ -1009,3 +1009,41 @@ def test_terminate_procs_kills_running_workers():
         ex.shutdown(wait=False, cancel_futures=True)
         if manager_thread is not None:
             manager_thread.join(5)
+
+
+@pytest.mark.unit
+class TestCountSync:
+    """The finalize-side synchronous counter.
+
+    Full-run OSL is computed after the run, outside the event loop, but it
+    must produce the same number the perf-side async path would for the same
+    input — otherwise the windowed and full-run statistics are not comparable
+    (mlcommons/endpoints#500).
+    """
+
+    @pytest.mark.asyncio
+    async def test_count_sync_agrees_with_count_batch_async(self):
+        """Same input, same count, whichever lane counted it."""
+        with patch(_MOCK_TARGET, _FakeTokenizerWithTemplate):
+            loop = asyncio.get_running_loop()
+            with BatchTokenizer("fake", n_workers=0, live_workers=2) as tok:
+                message = MessageInput(
+                    "hello world",
+                    "reasoning here",
+                    (
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        },
+                    ),
+                )
+                expected = (await tok.count_batch_async([message], loop))[0]
+
+                assert tok.count_sync(message) == expected
+
+    def test_count_sync_counts_plain_text(self):
+        """Text inputs take the text path, not the chat template."""
+        with patch(_MOCK_TARGET, _FakeTokenizerWithTemplate):
+            with BatchTokenizer("fake", n_workers=0, live_workers=2) as tok:
+                assert tok.count_sync(TextInput("hello world")) == 2

--- a/tests/unit/commands/test_full_run_osl.py
+++ b/tests/unit/commands/test_full_run_osl.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Full-run OSL: the all-turns statistic that complements the windowed one.
+
+The performance window closes when the first user finishes its final
+trajectory, so every turn issued afterwards is invisible to the perf-side
+``OslTrigger``. These tests pin the statistic that counts them
+(mlcommons/endpoints#500).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import msgspec
+import pytest
+from inference_endpoint.async_utils.services.metrics_aggregator.tokenization import (
+    MessageInput,
+    TextInput,
+)
+from inference_endpoint.commands.benchmark.full_run_osl import (
+    compute_full_run_osl,
+    full_run_osl_for_report,
+    load_performance_uuids,
+)
+from inference_endpoint.core.record import (
+    EventRecord,
+    EventType,
+    SampleEventType,
+    SessionEventType,
+)
+from inference_endpoint.core.types import TextModelOutput
+
+pytestmark = pytest.mark.unit
+
+_ENCODER = msgspec.json.Encoder(enc_hook=EventType.encode_hook)
+
+
+def _word_count(tok_input: MessageInput | TextInput) -> int:
+    """Deterministic stand-in for a real tokenizer."""
+    if isinstance(tok_input, TextInput):
+        return len(tok_input.text.split())
+    parts = [tok_input.content or "", tok_input.reasoning or ""]
+    if tok_input.tool_calls:
+        parts.append(" ".join(str(tc) for tc in tok_input.tool_calls))
+    return len(" ".join(parts).split())
+
+
+def _write_events(path: Path, records: list[EventRecord]) -> Path:
+    path.write_bytes(b"\n".join(_ENCODER.encode(r) for r in records) + b"\n")
+    return path
+
+
+def _complete(turn: int, text: str, uuid: str | None = None) -> EventRecord:
+    return EventRecord(
+        event_type=SampleEventType.COMPLETE,
+        sample_uuid=uuid or f"u{turn}",
+        conversation_id="c0",
+        turn=turn,
+        data=TextModelOutput(output=text),
+    )
+
+
+def _session(ev: SessionEventType) -> EventRecord:
+    return EventRecord(event_type=ev)
+
+
+def test_counts_turns_completed_after_the_performance_window(tmp_path: Path) -> None:
+    """Turns after STOP_PERFORMANCE_TRACKING are excluded from the window but
+    must appear in the full-run statistic.
+
+    Window sees 2 turns ("one" = 1 token, "two words" = 2). The tail adds two
+    more 3-token turns, which the perf-side OslTrigger never sees at all.
+    """
+    events = _write_events(
+        tmp_path / "events.jsonl",
+        [
+            _session(SessionEventType.STARTED),
+            _session(SessionEventType.START_PERFORMANCE_TRACKING),
+            _complete(1, "one"),
+            _complete(3, "two words"),
+            _session(SessionEventType.STOP_PERFORMANCE_TRACKING),
+            _complete(5, "a b c"),
+            _complete(7, "d e f"),
+            _session(SessionEventType.ENDED),
+        ],
+    )
+
+    result = compute_full_run_osl(events, _word_count)
+
+    assert result is not None
+    assert result["n_turns_counted"] == 4
+    # 1 + 2 + 3 + 3 = 9 tokens over 4 turns
+    assert result["output_sequence_lengths"]["total"] == 9
+    assert result["output_sequence_lengths"]["avg"] == 2.25
+
+
+def test_full_run_osl_is_invariant_to_window_position(tmp_path: Path) -> None:
+    """The #500 regression guard.
+
+    Identical per-turn outputs, but the performance window closes at two
+    different points — as it does when concurrency changes. The windowed mean
+    moves; the full-run mean must not. If this fails, the full-run statistic
+    has picked up the window gating and is no longer concurrency-independent.
+    """
+    turns = [_complete(2 * i + 1, " ".join("w" * (i + 1))) for i in range(6)]
+
+    def build(name: str, stop_after: int) -> Path:
+        return _write_events(
+            tmp_path / name,
+            [
+                _session(SessionEventType.STARTED),
+                _session(SessionEventType.START_PERFORMANCE_TRACKING),
+                *turns[:stop_after],
+                _session(SessionEventType.STOP_PERFORMANCE_TRACKING),
+                *turns[stop_after:],
+                _session(SessionEventType.ENDED),
+            ],
+        )
+
+    early = compute_full_run_osl(build("early.jsonl", 2), _word_count)
+    late = compute_full_run_osl(build("late.jsonl", 5), _word_count)
+
+    assert early is not None and late is not None
+    assert early["n_turns_counted"] == late["n_turns_counted"] == 6
+    assert early["output_sequence_lengths"] == late["output_sequence_lengths"]
+
+
+def test_excludes_completions_from_other_phases(tmp_path: Path) -> None:
+    """events.jsonl holds every phase's COMPLETE events.
+
+    A SWE-bench accuracy turn must not inflate the performance-phase full-run
+    OSL, so the population is bounded by the performance phase's uuids from
+    sample_idx_map.json.
+    """
+    events = _write_events(
+        tmp_path / "events.jsonl",
+        [
+            _session(SessionEventType.STARTED),
+            _session(SessionEventType.START_PERFORMANCE_TRACKING),
+            _complete(1, "one"),
+            _session(SessionEventType.STOP_PERFORMANCE_TRACKING),
+            _complete(3, "a b c"),
+            _complete(1, "x y z z z z z z", uuid="swebench-1"),
+            _session(SessionEventType.ENDED),
+        ],
+    )
+
+    result = compute_full_run_osl(events, _word_count, performance_uuids={"u1", "u3"})
+
+    assert result is not None
+    assert result["n_turns_counted"] == 2
+    assert result["output_sequence_lengths"]["total"] == 4
+
+
+def test_counts_empty_completions_separately(tmp_path: Path) -> None:
+    """A failed request logs COMPLETE with output == "".
+
+    It must not be counted as a zero-token sample, but it must still be
+    visible — a run full of blanks should not look like a clean short run.
+    """
+    events = _write_events(
+        tmp_path / "events.jsonl",
+        [
+            _session(SessionEventType.STARTED),
+            _complete(1, "one"),
+            _complete(3, ""),
+            _session(SessionEventType.ENDED),
+        ],
+    )
+
+    result = compute_full_run_osl(events, _word_count)
+
+    assert result is not None
+    assert result["n_turns_counted"] == 1
+    assert result["n_empty"] == 1
+
+
+def test_load_performance_uuids_reads_the_performance_phase(tmp_path: Path) -> None:
+    """sample_idx_map.json is keyed by dataset name; the perf phase is
+    "performance" (AgenticInferenceInlineScorer's dataset_name)."""
+    (tmp_path / "sample_idx_map.json").write_text(
+        '{"performance": {"u1": 0, "u3": 1}, "swe_bench": {"s1": 0}}'
+    )
+
+    assert load_performance_uuids(tmp_path) == {"u1", "u3"}
+
+
+def test_load_performance_uuids_returns_none_when_absent(tmp_path: Path) -> None:
+    """No map, or no performance phase, returns None; full_run_osl_for_report
+    treats that as "skip the block" (fail closed)."""
+    assert load_performance_uuids(tmp_path) is None
+
+    (tmp_path / "sample_idx_map.json").write_text('{"swe_bench": {"s1": 0}}')
+    assert load_performance_uuids(tmp_path) is None
+
+
+def test_full_run_mean_invariant_while_windowed_mean_moves(tmp_path: Path) -> None:
+    """#500 (f): under the performance uuid bound, the full-run mean is identical
+    across window positions even though the windowed (pre-STOP) mean differs. A
+    dataset repeat (distinct uuid) is counted; an out-of-population accuracy turn
+    is excluded and cannot move the mean."""
+    turns = [_complete(2 * i + 1, " ".join(["w"] * (i + 1))) for i in range(6)]
+    turns.append(_complete(13, "w w w", uuid="u13"))  # dataset repeat, distinct id
+    # An accuracy-phase completion NOT in the performance map — must be excluded.
+    swe = _complete(1, "x y z z z", uuid="swe-1")
+
+    perf_map = {r.sample_uuid: i for i, r in enumerate(turns)}
+    (tmp_path / "sample_idx_map.json").write_bytes(
+        msgspec.json.encode({"performance": perf_map, "swe_bench": {"swe-1": 0}})
+    )
+    uuids = load_performance_uuids(tmp_path)
+    assert uuids is not None and "swe-1" not in uuids
+
+    def build(name: str, stop_after: int) -> Path:
+        return _write_events(
+            tmp_path / name,
+            [
+                _session(SessionEventType.STARTED),
+                _session(SessionEventType.START_PERFORMANCE_TRACKING),
+                *turns[:stop_after],
+                _session(SessionEventType.STOP_PERFORMANCE_TRACKING),
+                *turns[stop_after:],
+                swe,  # out-of-population: must not affect the perf full-run mean
+                _session(SessionEventType.ENDED),
+            ],
+        )
+
+    def windowed_mean(stop_after: int) -> float:
+        counted = [_word_count(TextInput(str(r.data))) for r in turns[:stop_after]]
+        return sum(counted) / len(counted)
+
+    early = compute_full_run_osl(
+        build("e.jsonl", 2), _word_count, performance_uuids=uuids
+    )
+    late = compute_full_run_osl(
+        build("l.jsonl", 5), _word_count, performance_uuids=uuids
+    )
+
+    assert windowed_mean(2) != windowed_mean(5)  # the windowed mean moves
+    assert early is not None and late is not None
+    assert (
+        early["n_turns_counted"] == late["n_turns_counted"] == 7
+    )  # repeat in, swe out
+    assert early["output_sequence_lengths"] == late["output_sequence_lengths"]
+
+
+def test_data_none_completion_counts_as_empty(tmp_path: Path) -> None:
+    """A timed-out turn logs COMPLETE with data=None — counted as empty, not error."""
+    events = _write_events(
+        tmp_path / "events.jsonl",
+        [
+            _session(SessionEventType.STARTED),
+            _complete(1, "one"),
+            EventRecord(
+                event_type=SampleEventType.COMPLETE, sample_uuid="u3", turn=3, data=None
+            ),
+            _session(SessionEventType.ENDED),
+        ],
+    )
+
+    result = compute_full_run_osl(events, _word_count)
+
+    assert result is not None
+    assert result["n_turns_counted"] == 1
+    assert result["n_empty"] == 1
+    assert result["n_errors"] == 0
+
+
+def test_count_failure_is_isolated_to_n_errors(tmp_path: Path) -> None:
+    """One uncountable turn increments n_errors without voiding the stat."""
+    events = _write_events(
+        tmp_path / "events.jsonl",
+        [
+            _session(SessionEventType.STARTED),
+            _complete(1, "one"),
+            _complete(3, "boom"),
+            _session(SessionEventType.ENDED),
+        ],
+    )
+
+    def flaky(tok_input: MessageInput | TextInput) -> int:
+        if getattr(tok_input, "text", "") == "boom":
+            raise ValueError("tokenizer blew up")
+        return _word_count(tok_input)
+
+    result = compute_full_run_osl(events, flaky)
+
+    assert result is not None
+    assert result["n_turns_counted"] == 1
+    assert result["n_errors"] == 1
+    assert result["output_sequence_lengths"]["total"] == 1  # only "one" counted
+
+
+def test_all_empty_population_returns_a_visible_block(tmp_path: Path) -> None:
+    """A population with records but nothing countable returns a block (not None)
+    so the run is visible rather than looking uncomputed."""
+    events = _write_events(
+        tmp_path / "events.jsonl",
+        [
+            _session(SessionEventType.STARTED),
+            _complete(1, ""),
+            EventRecord(
+                event_type=SampleEventType.COMPLETE, sample_uuid="u3", turn=3, data=None
+            ),
+            _session(SessionEventType.ENDED),
+        ],
+    )
+
+    result = compute_full_run_osl(events, _word_count)
+
+    assert result is not None
+    assert result["n_turns_counted"] == 0
+    assert result["n_empty"] == 2
+    assert result["output_sequence_lengths"] == {}
+
+
+def test_undecodable_complete_line_is_skipped(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A corrupt COMPLETE line goes to n_undecodable (not n_errors/n_empty) and
+    warns once."""
+    path = tmp_path / "events.jsonl"
+    good = _ENCODER.encode(_complete(1, "one"))
+    # Trips the prefix marker but is not a decodable EventRecord.
+    corrupt = b'{"event_type":"sample.complete","data":<<<not json>>>}'
+    path.write_bytes(good + b"\n" + corrupt + b"\n")
+
+    with caplog.at_level(logging.WARNING):
+        result = compute_full_run_osl(path, _word_count)
+
+    assert result is not None
+    assert result["n_turns_counted"] == 1
+    assert result["n_errors"] == 0
+    assert result["n_empty"] == 0
+    assert result["n_undecodable"] == 1
+    messages = [r.getMessage() for r in caplog.records]
+    assert sum("undecodable COMPLETE line" in m for m in messages) == 1
+
+
+def test_all_undecodable_returns_visible_block(tmp_path: Path) -> None:
+    """A stream of only corrupt COMPLETE lines returns a block (not None) so the
+    accuracy field is not mistaken for uncomputed."""
+    corrupt = b'{"event_type":"sample.complete","data":<<<not json>>>}'
+    path = tmp_path / "events.jsonl"
+    path.write_bytes(corrupt + b"\n" + corrupt + b"\n")
+
+    result = compute_full_run_osl(path, _word_count)
+
+    assert result is not None
+    assert result["n_turns_counted"] == 0
+    assert result["n_undecodable"] == 2
+    assert result["output_sequence_lengths"] == {}
+
+
+def test_for_report_fails_closed_without_performance_map(tmp_path: Path) -> None:
+    """full_run_osl_for_report skips (returns None) when no performance uuid set
+    can be loaded — accuracy-phase turns must never count as performance OSL."""
+    (tmp_path / "events.jsonl").write_bytes(b"")  # exists so the events gate passes
+    # No sample_idx_map.json → load_performance_uuids None → fail closed, before
+    # any tokenizer is constructed.
+    assert full_run_osl_for_report(tmp_path, "any-tokenizer") is None
+
+
+def test_for_report_skips_without_tokenizer_or_events(tmp_path: Path) -> None:
+    """No tokenizer, or a missing events.jsonl, short-circuits to None."""
+    assert full_run_osl_for_report(tmp_path, None) is None  # no tokenizer
+    assert full_run_osl_for_report(tmp_path, "any-tokenizer") is None  # no events.jsonl

--- a/tests/unit/metrics/test_report_builder.py
+++ b/tests/unit/metrics/test_report_builder.py
@@ -574,6 +574,81 @@ class TestReportDisplayAndSerialize:
         output = "\n".join(lines)
         assert "WARNING" in output or "incomplete" in output.lower()
 
+    def _report_with_full_run_osl(self, fr, *, osl_windowed=None, complete=True):
+        return Report(
+            version="test",
+            git_sha=None,
+            test_started_at=0,
+            n_samples_issued=10,
+            n_samples_completed=10,
+            n_samples_failed=0,
+            duration_ns=1_000_000_000,
+            state="complete" if complete else "interrupted",
+            complete=complete,
+            ttft={},
+            tpot={},
+            latency={},
+            input_sequence_lengths={},
+            output_sequence_lengths=osl_windowed or {},
+            output_sequence_lengths_full_run=fr,
+        )
+
+    def test_display_full_run_osl_mean(self):
+        """A block with counted turns prints the accuracy per-turn mean."""
+        report = self._report_with_full_run_osl(
+            {
+                "output_sequence_lengths": {"avg": 412.5},
+                "n_turns_counted": 1055,
+                "n_empty": 3,
+                "n_errors": 0,
+            }
+        )
+        lines: list[str] = []
+        report.display(fn=lines.append, summary_only=True)
+        output = "".join(lines)
+        assert (
+            "OSL per-turn mean (accuracy, all turns): 412.5 tokens over 1055 turns"
+            in output
+        )
+
+    def test_display_full_run_osl_no_countable_turns(self):
+        """An all-empty/all-error block prints counts, not a fabricated 0.0 mean."""
+        report = self._report_with_full_run_osl(
+            {
+                "output_sequence_lengths": {},
+                "n_turns_counted": 0,
+                "n_empty": 5,
+                "n_errors": 2,
+            }
+        )
+        lines: list[str] = []
+        report.display(fn=lines.append, summary_only=True)
+        output = "".join(lines)
+        assert "no countable turns" in output
+        assert "0.0 tokens" not in output
+
+    def test_display_full_run_osl_missing_on_complete_performance_run(self):
+        """A COMPLETE perf run (windowed OSL present) with no full-run block
+        blames the tokenizer/sample-map, not incompleteness."""
+        report = self._report_with_full_run_osl(None, osl_windowed={"avg": 100.0})
+        lines: list[str] = []
+        report.display(fn=lines.append, summary_only=True)
+        output = "".join(lines)
+        assert "no tokenizer or unreadable sample map" in output
+        assert "run incomplete" not in output
+
+    def test_display_full_run_osl_incomplete_run_with_windowed_osl(self):
+        """An INTERRUPTED perf run (windowed OSL present, no block) must report
+        incompleteness — not a false tokenizer/sample-map diagnosis."""
+        report = self._report_with_full_run_osl(
+            None, osl_windowed={"avg": 100.0}, complete=False
+        )
+        lines: list[str] = []
+        report.display(fn=lines.append, summary_only=True)
+        output = "".join(lines)
+        assert "run incomplete" in output
+        assert "no tokenizer or unreadable sample map" not in output
+
     def test_display_warns_when_interrupted(self):
         """Reports with ``state == "interrupted"`` surface a distinct WARNING."""
         report = Report(


### PR DESCRIPTION
## Summary

Resolves #500.

Agentic-inference runs stop performance tracking when the first active user finishes its final trajectory, so turns issued after that boundary are excluded from the windowed output-sequence-length (OSL). Because the excluded tail depends on concurrency, the reported mean OSL differs across Pareto points even when the model produces identical output — which biases the **per-turn mean OSL accuracy requirement** (see the [Tail Management](examples/10_Agentic_Inference/README.md#tail-management) section).

This PR adds a **separate full-run OSL** computed over **every** completed turn — tail and dataset repeats included — for use as the accuracy-gate statistic, while leaving the windowed OSL untouched for throughput.

## What changed

- **`commands/benchmark/full_run_osl.py`** (new): a post-finalize, streaming, prefix-gated scan of `events.jsonl` that rolls up OSL over all in-population COMPLETE turns. The population is bounded to the performance phase via `sample_idx_map.json` and **fails closed** (skips) when that map is unavailable, so accuracy-phase turns can never be counted as performance OSL. Reports `n_turns_counted` / `n_empty` / `n_errors` / `n_undecodable` so a partial or all-blank run stays visible rather than looking uncomputed.
- **`metrics_aggregator/tokenization.py`**: `output_tokenization_input` — the single shared rule for how a model output (including reasoning and tool calls) is rendered for counting. Both the windowed `OslTrigger` and the full-run scan use it, so the two numbers are directly comparable.
- **`metrics_aggregator/token_metrics.py`**: `BatchTokenizer.count_sync` for finalize-side (post-event-loop) counting that matches the async path exactly; teardown is guarded so the in-process (`n_workers=0`) tokenizer never terminates unrelated child processes.
- **`commands/benchmark/execute.py`**: computes and attaches the block at finalize, inside the report-writing `try/finally` (skipped on abort so a partial tail is never reported as complete).
- **`metrics/report.py`**: new optional `output_sequence_lengths_full_run` field, plus a `report.txt` line labeled as the accuracy OSL (with an explicit note when it is missing or the run is incomplete).
- **`examples/10_Agentic_Inference/README.md`**: documents `output_sequence_lengths_full_run.output_sequence_lengths.avg` as the field to read for the OSL accuracy gate — a run is invalid for the gate when this is `null`, `n_turns_counted == 0`, or the run is not `complete`.

## Testing

```
uv run pytest -m unit \
  tests/unit/commands/test_full_run_osl.py \
  tests/unit/metrics/test_report_builder.py \
  tests/unit/async_utils/services/metrics_aggregator/test_output_tokenization_rule.py
```

Includes the issue #500 (f) regression guard: the full-run mean stays identical when the performance window closes at different points, even as the windowed mean moves. (Pre-existing macOS-only IPC-socket / CPU-affinity test failures are unrelated to this change.)

## Notes

- The single `Sync` commit can be squashed/renamed on merge.
- Draft: opening for review. A few optional test-hardening follow-ups (an isolation test for a raising `output_tokenization_input`, a direct test of the tokenizer-teardown guard) are not yet included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
